### PR TITLE
Fix some types

### DIFF
--- a/src/ExpoIap.types.ts
+++ b/src/ExpoIap.types.ts
@@ -35,7 +35,8 @@ enum PurchaseStateAndroid {
 }
 
 export type ProductPurchase = {
-  productId: string;
+  productID: string;
+  originalID: number;
   transactionId?: string;
   transactionDate: number;
   transactionReceipt: string;


### PR DESCRIPTION
I was testing the example app with store kit and noticed the types that were automatically generated by XCode for the store kit config didn't match those in the module.