### PR TITLE
Fix Android IAP Crash & Transaction Flow

### DIFF
--- a/android/src/main/java/expo/modules/iap/PlayUtils.kt
+++ b/android/src/main/java/expo/modules/iap/PlayUtils.kt
@@ -29,6 +29,76 @@ object PromiseUtils {
     const val E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR"
     const val E_BILLING_RESPONSE_JSON_PARSE_ERROR = "E_BILLING_RESPONSE_JSON_PARSE_ERROR"
     const val E_CONNECTION_CLOSED = "E_CONNECTION_CLOSED"
+
+    fun addPromiseForKey(
+        key: String,
+        promise: Promise,
+    ) {
+        promises.getOrPut(key) { mutableListOf() }.add(promise)
+    }
+
+    fun resolvePromisesForKey(
+        key: String,
+        value: Any?,
+    ) {
+        promises[key]?.forEach { promise ->
+            promise.safeResolve(value)
+        }
+        promises.remove(key)
+    }
+
+    fun rejectAllPendingPromises() {
+        promises.flatMap { it.value }.forEach { promise ->
+            promise.safeReject(E_CONNECTION_CLOSED, "Connection has been closed", null)
+        }
+        promises.clear()
+    }
+
+    fun rejectPromisesForKey(
+        key: String,
+        code: String,
+        message: String?,
+        err: Exception?,
+    ) {
+        promises[key]?.forEach { promise ->
+            promise.safeReject(code, message, err)
+        }
+        promises.remove(key)
+    }
+}
+
+const val TAG = "IapPromises"
+
+fun Promise.safeResolve(value: Any?) {
+    try {
+        this.resolve(value)
+    } catch (e: RuntimeException) {
+        Log.d(TAG, "Already consumed ${e.message}")
+    }
+}
+
+fun Promise.safeReject(message: String) = this.safeReject(message, null, null)
+
+fun Promise.safeReject(
+    code: String,
+    message: String?,
+) = this.safeReject(code, message, null)
+
+fun Promise.safeReject(
+    code: String,
+    throwable: Throwable?,
+) = this.safeReject(code, null, throwable)
+
+fun Promise.safeReject(
+    code: String,
+    message: String?,
+    throwable: Throwable?,
+) {
+    try {
+        this.reject(code, message, throwable)
+    } catch (e: RuntimeException) {
+        Log.d(TAG, "Already consumed ${e.message}")
+    }
 }
 
 object PlayUtils {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from './ExpoIap.types';
 import ExpoIapModule from './ExpoIapModule';
 import {
+  ProductPurchaseAndroid,
   RequestPurchaseAndroidProps,
   RequestSubscriptionAndroidProps,
 } from './types/ExpoIapAndroid.types';
@@ -323,20 +324,20 @@ export const finishTransaction = ({
         return Promise.resolve(true);
       },
       android: async () => {
-        // Check if the purchase is from Android by checking the platform property
-        if (
-          purchase.platform !== 'android' ||
-          !('purchaseTokenAndroid' in purchase)
-        ) {
+        const androidPurchase = purchase as ProductPurchaseAndroid;
+
+        if (!('purchaseTokenAndroid' in androidPurchase)) {
           return Promise.reject(
-            new Error('purchaseTokenAndroid is required to finish transaction'),
+            new Error('purchaseToken is required to finish transaction'),
           );
         }
         if (isConsumable) {
-          return ExpoIapModule.consumeProduct(purchase.purchaseTokenAndroid);
+          return ExpoIapModule.consumeProduct(
+            androidPurchase.purchaseTokenAndroid,
+          );
         } else {
           return ExpoIapModule.acknowledgePurchase(
-            purchase.purchaseTokenAndroid,
+            androidPurchase.purchaseTokenAndroid,
           );
         }
       },

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -7,6 +7,7 @@ import {
   getProducts,
   getAvailablePurchases,
   getPurchaseHistory,
+  finishTransaction as finishTransactionInternal,
   getSubscriptions,
 } from './';
 import {useCallback, useEffect, useState, useRef} from 'react';
@@ -35,11 +36,9 @@ type IAP_STATUS = {
   finishTransaction: ({
     purchase,
     isConsumable,
-    developerPayloadAndroid,
   }: {
     purchase: Purchase;
     isConsumable?: boolean;
-    developerPayloadAndroid?: string;
   }) => Promise<string | boolean | PurchaseResult | void>;
   getAvailablePurchases: () => Promise<void>;
   getPurchaseHistories: () => Promise<void>;
@@ -94,17 +93,14 @@ export function useIAP(): IAP_STATUS {
     async ({
       purchase,
       isConsumable,
-      developerPayloadAndroid,
     }: {
       purchase: ProductPurchase;
       isConsumable?: boolean;
-      developerPayloadAndroid?: string;
     }): Promise<string | boolean | PurchaseResult | void> => {
       try {
-        return await finishTransaction({
+        return await finishTransactionInternal({
           purchase,
           isConsumable,
-          developerPayloadAndroid,
         });
       } catch (err) {
         throw err;


### PR DESCRIPTION
This PR fixes an Android IAP crash and improves transaction handling:

1. **Safe Event Handling**: Wrapped `sendEvent` in `try-catch` to prevent `NullPointerException` crashes in `ExpoIapModule` (Commit: `fix: safely handle events in android mod`).
2. **Transaction Fix**: Enhanced `finishTransaction` in `useIap` for stable async flow (Commit: `fix: finishTransaction in useIap`).
