### PR TITLE
Add top-level currency and displayPrice to product details response

### DIFF
--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -179,8 +179,10 @@ class ExpoIapModule :
 
                                 val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
                                     ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
+                                    ?: "Unknown"
                                 val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
                                     ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
+                                    ?: "N/A"
 
                                 mapOf(
                                     "id" to productDetails.productId,

--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -177,6 +177,11 @@ class ExpoIapModule :
                             productDetailsList.map { productDetails ->
                                 skus[productDetails.productId] = productDetails
 
+                                val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
+                                    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
+                                val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
+                                    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
+
                                 mapOf(
                                     "id" to productDetails.productId,
                                     "title" to productDetails.title,
@@ -184,6 +189,8 @@ class ExpoIapModule :
                                     "type" to productDetails.productType,
                                     "displayName" to productDetails.name,
                                     "platform" to "android",
+                                    "currency" to currency,
+                                    "displayPrice" to displayPrice,
                                     "oneTimePurchaseOfferDetails" to
                                         productDetails.oneTimePurchaseOfferDetails?.let {
                                             mapOf(

--- a/src/ExpoIap.types.ts
+++ b/src/ExpoIap.types.ts
@@ -26,9 +26,9 @@ export type ProductBase = {
   description: string;
   type: ProductType;
   displayName?: string;
-  displayPrice?: string;
+  displayPrice: string;
+  currency: string;
   price?: number;
-  currency?: string;
 };
 
 // Define literal platform types for better type discrimination

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -22,7 +22,6 @@ type SubscriptionInfo = {
 
 export type ProductIos = ProductBase & {
   displayName: string;
-  displayPrice: string;
   isFamilyShareable: boolean;
   jsonRepresentation: string;
   subscription: SubscriptionInfo;


### PR DESCRIPTION
### Changes
- Added `currency` and `displayPrice` at the top level of `ProductDetails` response.
  - Uses `oneTimePurchaseOfferDetails` or falls back to `subscriptionOfferDetails`’s first pricing phase.
- Updated `ProductBase` TypeScript type with `displayPrice` and `currency`.
- Aligns with iOS, where these fields are top-level (see below).

### Code
#### Kotlin (Android)
```kotlin
val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
mapOf("currency" to currency, "displayPrice" to displayPrice, /* ... */)
```

#### TypeScript
```typescript
export type ProductBase = {
  id: string;
  title: string;
  description: string;
  type: ProductType;
  displayName?: string;
  displayPrice: string;
  currency: string;
  price?: number;
};
```

#### iOS Reference
```swift
@available(iOS 15.0, *)
func serializeProduct(_ p: Product) -> [String: Any?] {
    return ["displayPrice": p.displayPrice, "currency": p.priceFormatStyle.currencyCode, /* ... */]
}
```
