### PR TITLE
fix(ios): signature encoding

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -321,7 +321,7 @@ public class ExpoIapModule: Module {
                         let signature = discountOffer?["signature"],
                         let timestamp = discountOffer?["timestamp"],
                         let uuidNonce = UUID(uuidString: nonce),
-                        let signatureData = signature.data(using: .utf8),
+                        let signatureData = Data(base64Encoded: signature),
                         let timestampInt = Int(timestamp)
                     {
                         options.insert(


### PR DESCRIPTION
Closes #27

I want to use expo-iap, so I fix this issue.
Without this, receipt verification is not possible.