### PR TITLE
feat: add verified jws representation to serializeTransaction

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -16,7 +16,7 @@ struct IapEvent {
 }
 
 @available(iOS 15.0, *)
-func serializeTransaction(_ transaction: Transaction) -> [String: Any?] {
+func serializeTransaction(_ transaction: Transaction, jwsRepresentation: String? = nil) -> [String: Any?] {
     let isSubscription =
         transaction.productType.rawValue.lowercased().contains("renewable")
         || transaction.expirationDate != nil
@@ -70,6 +70,10 @@ func serializeTransaction(_ transaction: Transaction) -> [String: Any?] {
         "transactionReasonIos": transactionReasonIos,
     ]
 
+    if (jwsRepresentation != nil) {
+        purchaseMap["jwsRepresentation"] = jwsRepresentation
+    }
+    
     if #available(iOS 16.0, *) {
         purchaseMap["environmentIos"] = transaction.environment.rawValue
     }
@@ -361,7 +365,7 @@ public class ExpoIapModule: Module {
                             return nil
                         } else {
                             self.transactions[String(transaction.id)] = transaction
-                            let serialized = serializeTransaction(transaction)
+                            let serialized = serializeTransaction(transaction, jwsRepresentation: verification.jwsRepresentation)
                             self.sendEvent(IapEvent.PurchaseUpdated, serialized)
                             return serialized
                         }

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -16,7 +16,7 @@ struct IapEvent {
 }
 
 @available(iOS 15.0, *)
-func serializeTransaction(_ transaction: Transaction, jwsRepresentation: String? = nil) -> [String: Any?] {
+func serializeTransaction(_ transaction: Transaction, jwsRepresentationIos: String? = nil) -> [String: Any?] {
     let isSubscription =
         transaction.productType.rawValue.lowercased().contains("renewable")
         || transaction.expirationDate != nil
@@ -70,8 +70,8 @@ func serializeTransaction(_ transaction: Transaction, jwsRepresentation: String?
         "transactionReasonIos": transactionReasonIos,
     ]
 
-    if (jwsRepresentation != nil) {
-        purchaseMap["jwsRepresentation"] = jwsRepresentation
+    if (jwsRepresentationIos != nil) {
+        purchaseMap["jwsRepresentationIos"] = jwsRepresentationIos
     }
     
     if #available(iOS 16.0, *) {
@@ -365,7 +365,7 @@ public class ExpoIapModule: Module {
                             return nil
                         } else {
                             self.transactions[String(transaction.id)] = transaction
-                            let serialized = serializeTransaction(transaction, jwsRepresentation: verification.jwsRepresentation)
+                            let serialized = serializeTransaction(transaction, jwsRepresentationIos: verification.jwsRepresentation)
                             self.sendEvent(IapEvent.PurchaseUpdated, serialized)
                             return serialized
                         }

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -133,4 +133,5 @@ export type ProductPurchaseIos = PurchaseBase & {
   };
   priceIos?: number;
   currencyIos?: string;
+  jwsRepresentation?: string;
 };

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -133,5 +133,5 @@ export type ProductPurchaseIos = PurchaseBase & {
   };
   priceIos?: number;
   currencyIos?: string;
-  jwsRepresentation?: string;
+  jwsRepresentationIos?: string;
 };


### PR DESCRIPTION
Possible fix to #34 

As stated in the StoreKit [documentation](https://developer.apple.com/documentation/storekit/transaction#Verify-transactions):

> To perform your own validation on the device, use the verification result’s jwsRepresentation string, and use the provided convenience properties headerData, payloadData, and signatureData. For added control and security, send the jwsRepresentation to your server to verify.

However, the current return value of the library's `requestPurchase` only returns the `jsonRepresentation` of the `Transaction` object, and not `jwsRepresentation` of the verification result, which makes it more complicated to implement a server-side verification.

With this change, user can correctly get the required `JWS` that they can use to implement their own verification during the `purchase` flow.