### PR TITLE
add jwsRepresentationIos to the returned map of getAvailableItems

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -235,7 +235,7 @@ public class ExpoIapModule: Module {
             var purchasedItemsSerialized: [[String: Any?]] = []
 
             func addTransaction(transaction: Transaction, jwsRepresentationIos: String? = nil) {
-                purchasedItemsSerialized.append(serializeTransaction(transaction, jwsRepresentationIos))
+                purchasedItemsSerialized.append(serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos))
                 if alsoPublishToEventListener {
                     self.sendEvent(IapEvent.PurchaseUpdated, serializeTransaction(transaction))
                 }

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -237,7 +237,7 @@ public class ExpoIapModule: Module {
             func addTransaction(transaction: Transaction, jwsRepresentationIos: String? = nil) {
                 purchasedItemsSerialized.append(serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos))
                 if alsoPublishToEventListener {
-                    self.sendEvent(IapEvent.PurchaseUpdated, serializeTransaction(transaction))
+                    self.sendEvent(IapEvent.PurchaseUpdated, serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos))
                 }
             }
 

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -232,10 +232,10 @@ public class ExpoIapModule: Module {
 
         AsyncFunction("getAvailableItems") {
             (alsoPublishToEventListener: Bool, onlyIncludeActiveItems: Bool) -> [[String: Any?]?] in
-            var purchasedItems: [Transaction] = []
+            var purchasedItemsSerialized: [[String: Any?]] = []
 
-            func addTransaction(transaction: Transaction) {
-                purchasedItems.append(transaction)
+            func addTransaction(transaction: Transaction, jwsRepresentationIos: String? = nil) {
+                purchasedItemsSerialized.append(serializeTransaction(transaction, jwsRepresentationIos))
                 if alsoPublishToEventListener {
                     self.sendEvent(IapEvent.PurchaseUpdated, serializeTransaction(transaction))
                 }
@@ -247,13 +247,13 @@ public class ExpoIapModule: Module {
                 }
             }
 
-            for await result in onlyIncludeActiveItems
+            for await verification in onlyIncludeActiveItems
                 ? Transaction.currentEntitlements : Transaction.all
             {
                 do {
-                    let transaction = try self.checkVerified(result)
+                    let transaction = try self.checkVerified(verification)
                     if !onlyIncludeActiveItems {
-                        addTransaction(transaction: transaction)
+                        addTransaction(transaction: transaction, jwsRepresentationIos: verification.jwsRepresentation)
                         continue
                     }
                     switch transaction.productType {
@@ -261,7 +261,7 @@ public class ExpoIapModule: Module {
                         if await self.productStore?.getProduct(productID: transaction.productID)
                             != nil
                         {
-                            addTransaction(transaction: transaction)
+                            addTransaction(transaction: transaction, jwsRepresentationIos: verification.jwsRepresentation)
                         }
                     case .nonRenewable:
                         if await self.productStore?.getProduct(productID: transaction.productID)
@@ -271,7 +271,7 @@ public class ExpoIapModule: Module {
                             let expirationDate = Calendar(identifier: .gregorian).date(
                                 byAdding: DateComponents(year: 1), to: transaction.purchaseDate)!
                             if currentDate < expirationDate {
-                                addTransaction(transaction: transaction)
+                                addTransaction(transaction: transaction, jwsRepresentationIos: verification.jwsRepresentation)
                             }
                         }
                     default:
@@ -298,7 +298,7 @@ public class ExpoIapModule: Module {
                 }
             }
 
-            return purchasedItems.map { serializeTransaction($0) }
+            return purchasedItemsSerialized
         }
 
         AsyncFunction("buyProduct") {

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -109,7 +109,6 @@ export type ProductPurchaseIos = PurchaseBase & {
   quantityIos?: number;
   originalTransactionDateIos?: number;
   originalTransactionIdentifierIos?: string;
-  verificationResultIos?: string;
   appAccountToken?: string;
   // iOS additional fields from StoreKit 2
   expirationDateIos?: number;


### PR DESCRIPTION
fixes #44 ?

ports https://github.com/hyochan/react-native-iap/pull/2874 to `expo-iap`

which makes `getAvailableItems` includes `jwsRepresentationIos` in the returned map.

Also deletes `verificationResultIos` in the type since its not used anywhere
