### PR TITLE
fix: EAS Build compatibility issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 group = 'expo.modules.iap'
 version = '0.1.0'
@@ -40,4 +41,10 @@ android {
   lintOptions {
     abortOnError false
   }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
+    implementation "com.android.billingclient:billing-ktx:7.0.0"
+    implementation "com.google.android.gms:play-services-base:18.1.0"
 }

--- a/plugin/src/withIAP.ts
+++ b/plugin/src/withIAP.ts
@@ -1,7 +1,7 @@
 import {
   WarningAggregator,
   withAndroidManifest,
-  withProjectBuildGradle,
+  withAppBuildGradle,
   ConfigPlugin,
   createRunOncePlugin,
 } from 'expo/config-plugins';
@@ -27,16 +27,10 @@ const addLineToGradle = (
   return lines.join('\n');
 };
 
-const modifyProjectBuildGradle = (gradle: string): string => {
+const modifyAppBuildGradle = (gradle: string): string => {
   let modified = gradle;
 
-  // 1. supportLibVersion
-  const supportLib = `supportLibVersion = "28.0.0"`;
-  if (!modified.includes(supportLib)) {
-    modified = addLineToGradle(modified, /ext\s*{/, supportLib);
-  }
-
-  // 2. billing library
+  // Add billing library dependencies to app-level build.gradle
   const billingDep = `    implementation "com.android.billingclient:billing-ktx:7.0.0"`;
   const gmsDep = `    implementation "com.google.android.gms:play-services-base:18.1.0"`;
   if (!modified.includes(billingDep)) {
@@ -50,8 +44,9 @@ const modifyProjectBuildGradle = (gradle: string): string => {
 };
 
 const withIAPAndroid: ConfigPlugin = (config) => {
-  config = withProjectBuildGradle(config, (config) => {
-    config.modResults.contents = modifyProjectBuildGradle(
+  // Add IAP dependencies to app build.gradle
+  config = withAppBuildGradle(config, (config) => {
+    config.modResults.contents = modifyAppBuildGradle(
       config.modResults.contents,
     );
     return config;


### PR DESCRIPTION
This PR resolves a build error occurring on EAS by switching from `withProjectBuildGradle` to `withAppBuildGradle`, ensuring that billing dependencies (`billing-ktx` and `play-services-base`) are correctly injected into the app-level `build.gradle` instead of the project-level one.

**Changes:**

* Replaced `withProjectBuildGradle` with `withAppBuildGradle`
* Removed unused `supportLibVersion` config
* Ensured billing permissions and dependencies are properly set in AndroidManifest and `app/build.gradle`

This fixes build failures on EAS and ensures compatibility with the latest Expo SDK.
