### PR TITLE
fix: subscription renewal status not emitting events

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -20,6 +20,7 @@
       "package": "com.crossplatformkorea.cpk"
     },
     "plugins": [
+      "expo-iap",
       "expo-router",
       [
         "expo-splash-screen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.4-rc.1",
+  "version": "2.3.4-rc.2",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.3",
+  "version": "2.3.4-rc.1",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -72,7 +72,10 @@ export const beginRefundRequest = (sku: string): Promise<RefundRequestStatus> =>
   ExpoIapModule.beginRefundRequest(sku);
 
 /**
- *
+ * Shows the system UI for managing subscriptions.
+ * When the user changes subscription renewal status, the system will emit events to 
+ * purchaseUpdatedListener and transactionUpdatedIos listeners.
+ * @returns {Promise<null>}
  */
 export const showManageSubscriptions = (): Promise<null> =>
   ExpoIapModule.showManageSubscriptions();

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -10,6 +10,7 @@ import {
   finishTransaction as finishTransactionInternal,
   getSubscriptions,
   requestPurchase as requestPurchaseInternal,
+  sync,
 } from './';
 import {useCallback, useEffect, useState, useRef} from 'react';
 import {
@@ -155,6 +156,23 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [clearCurrentPurchase, clearCurrentPurchaseError],
   );
 
+  const refreshSubscriptionStatus = useCallback(async (productId: string) => {
+    try {
+      if (Platform.OS === 'ios') {
+        await sync().catch(() => {
+          // Ignore errors as sync might require user password
+        });
+      }
+      
+      if (subscriptions.some(sub => sub.id === productId)) {
+        await getSubscriptionsInternal([productId]);
+        await getAvailablePurchasesInternal();
+      }
+    } catch (error) {
+      console.warn('Failed to refresh subscription status:', error);
+    }
+  }, [getSubscriptionsInternal, getAvailablePurchasesInternal, subscriptions]);
+
   const initIapWithSubscriptions = useCallback(async (): Promise<void> => {
     const result = await initConnection();
     setConnected(result);
@@ -164,6 +182,10 @@ export function useIAP(options?: UseIAPOptions): UseIap {
         async (purchase: Purchase | SubscriptionPurchase) => {
           setCurrentPurchaseError(undefined);
           setCurrentPurchase(purchase);
+
+          if ('expirationDateIos' in purchase) {
+            await refreshSubscriptionStatus(purchase.id);
+          }
 
           if (optionsRef.current?.onPurchaseSuccess) {
             optionsRef.current.onPurchaseSuccess(purchase);
@@ -184,17 +206,21 @@ export function useIAP(options?: UseIAPOptions): UseIap {
 
       if (Platform.OS === 'ios') {
         subscriptionsRef.current.promotedProductsIos = transactionUpdatedIos(
-          (event: TransactionEvent) => {
-            setPromotedProductsIOS((prevProducts) =>
-              event.transaction
-                ? [...prevProducts, event.transaction]
-                : prevProducts,
-            );
+          async (event: TransactionEvent) => {
+            if (event.transaction) {
+              setPromotedProductsIOS((prevProducts) => 
+                [...prevProducts, event.transaction!]
+              );
+              
+              if ('expirationDateIos' in event.transaction) {
+                await refreshSubscriptionStatus(event.transaction.id);
+              }
+            }
           },
         );
       }
     }
-  }, []);
+  }, [refreshSubscriptionStatus]);
 
   useEffect(() => {
     initIapWithSubscriptions();

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -54,6 +54,7 @@ type UseIap = {
 export interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: ProductPurchase | SubscriptionPurchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
+  onSyncError?: (error: Error) => void;
 }
 
 export function useIAP(options?: UseIAPOptions): UseIap {
@@ -159,8 +160,14 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   const refreshSubscriptionStatus = useCallback(async (productId: string) => {
     try {
       if (Platform.OS === 'ios') {
-        await sync().catch(() => {
-          // Ignore errors as sync might require user password
+        await sync().catch((error) => {
+          // Pass the error to the developer's handler if provided
+          if (optionsRef.current?.onSyncError) {
+            optionsRef.current.onSyncError(error);
+          } else {
+            // Fallback to original behavior
+            console.warn('Sync error occurred. This might require user password:', error);
+          }
         });
       }
       


### PR DESCRIPTION
## Description

This PR addresses an issue where changing subscription renewal status through iOS subscription management UI (via `showManageSubscriptions()`) didn't emit any events to the app. This made it difficult for apps to stay in sync with subscription status changes without manually polling.

## Solution

When users changed their subscription renewal status (for example, toggling off auto-renewal) through Apple's subscription management UI, the app had no way of knowing about this change. This resulted in stale data being displayed to the user until the app was restarted or manual API calls were made.

## Implementation
The solution implements a polling mechanism that runs after the subscription management UI is dismissed:

1. Before showing the management UI, we collect all subscription product IDs
2. After the UI is dismissed, we start a polling task that:
    * Captures the initial renewal status of all subscriptions
    * Polls multiple times with delays to detect any changes
    * When a change is detected, proper events are emitted to both `purchaseUpdatedListener` and `transactionUpdatedIos` listeners

## Testing

1. Purchase a subscription in the app
2. Use `showManageSubscriptions()` to open the subscription management UI
3. Change the renewal status (toggle auto-renewal off)
4. Close the management UI
5. The app should now receive an event through the purchase update listener with the updated renewal status

This solution is non-intrusive and works with the existing API, maintaining backward compatibility.

Fixes #38 