### PR TITLE
Add iOS receipt validation functionality

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -645,6 +645,110 @@ public class ExpoIapModule: Module {
             self.removeTransactionObserver()
             return true
         }
+
+        AsyncFunction("getReceiptData") { () -> String? in
+            if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
+               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
+                do {
+                    let receiptData = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+                    return receiptData.base64EncodedString(options: [])
+                } catch {
+                    throw NSError(
+                        domain: "ExpoIapModule", code: 13,
+                        userInfo: [
+                            NSLocalizedDescriptionKey:
+                                "Error reading receipt data: \(error.localizedDescription)"
+                        ])
+                }
+            } else {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 14,
+                    userInfo: [NSLocalizedDescriptionKey: "App Store receipt not found"])
+            }
+        }
+        
+        AsyncFunction("isTransactionVerified") { (sku: String) -> Bool in
+            guard let productStore = self.productStore else {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Connection not initialized"])
+            }
+            
+            if let product = await productStore.getProduct(productID: sku),
+               let result = await product.latestTransaction {
+                do {
+                    // If this doesn't throw, the transaction is verified
+                    _ = try self.checkVerified(result)
+                    return true
+                } catch {
+                    return false
+                }
+            }
+            return false
+        }
+        
+        AsyncFunction("getTransactionJws") { (sku: String) -> String? in
+            guard let productStore = self.productStore else {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Connection not initialized"])
+            }
+            
+            if let product = await productStore.getProduct(productID: sku),
+               let result = await product.latestTransaction {
+                return result.jwsRepresentation
+            } else {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 5,
+                    userInfo: [NSLocalizedDescriptionKey: "Can't find transaction for sku \(sku)"])
+            }
+        }
+        
+        AsyncFunction("validateReceiptIos") { (sku: String) -> [String: Any] in
+            guard let productStore = self.productStore else {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Connection not initialized"])
+            }
+            
+            // Get receipt data
+            var receiptData: String? = nil
+            if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
+               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
+                do {
+                    let receiptDataRaw = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+                    receiptData = receiptDataRaw.base64EncodedString(options: [])
+                } catch {
+                    print("Error reading receipt data: \(error.localizedDescription)")
+                }
+            }
+            
+            var isValid = false
+            var jwsRepresentation: String? = nil
+            var latestTransaction: [String: Any?]? = nil
+            
+            // Get JWS representation and verify transaction
+            if let product = await productStore.getProduct(productID: sku),
+               let result = await product.latestTransaction {
+                jwsRepresentation = result.jwsRepresentation
+                
+                do {
+                    // If this doesn't throw, the transaction is verified
+                    let transaction = try self.checkVerified(result)
+                    isValid = true
+                    latestTransaction = serializeTransaction(transaction, jwsRepresentationIos: result.jwsRepresentation)
+                } catch {
+                    isValid = false
+                }
+            }
+            
+            return [
+                "isValid": isValid,
+                "receiptData": receiptData ?? "",
+                "jwsRepresentation": jwsRepresentation ?? "",
+                "latestTransaction": latestTransaction as Any
+            ]
+        }
     }
 
     private func addTransactionObserver() {

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -840,14 +840,18 @@ public class ExpoIapModule: Module {
         subscriptionPollingTask = Task {
             try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
             
-            var previousStatuses: [String: Product.SubscriptionInfo.RenewalState] = [:]
+            var previousStatuses: [String: Bool] = [:] // Track auto-renewal state with Bool
             
             for sku in self.pollingSkus {
                 guard let product = await self.productStore?.getProduct(productID: sku),
                       let status = try? await product.subscription?.status.first else { continue }
                 
-                previousStatuses[sku] = status.renewalInfo.verified?.willAutoRenew == true ? 
-                    .willRenew : .willNotRenew
+                // Track willAutoRenew as a bool value
+                var willAutoRenew = false
+                if case .verified(let info) = status.renewalInfo {
+                    willAutoRenew = info.willAutoRenew
+                }
+                previousStatuses[sku] = willAutoRenew
             }
             
             for _ in 1...5 {
@@ -860,18 +864,29 @@ public class ExpoIapModule: Module {
                 for sku in self.pollingSkus {
                     guard let product = await self.productStore?.getProduct(productID: sku),
                           let status = try? await product.subscription?.status.first,
-                          let transaction = await product.latestTransaction?.verified else { continue }
+                          let result = await product.latestTransaction else { continue }
                     
-                    let currentRenewalState = status.renewalInfo.verified?.willAutoRenew == true ? 
-                        Product.SubscriptionInfo.RenewalState.willRenew : 
-                        Product.SubscriptionInfo.RenewalState.willNotRenew
+                    // Try to verify the transaction
+                    let transaction: Transaction
+                    do {
+                        transaction = try self.checkVerified(result)
+                    } catch {
+                        continue // Skip if verification fails
+                    }
                     
-                    if let previousState = previousStatuses[sku], 
-                       previousState != currentRenewalState {
+                    // Track current auto-renewal state
+                    var currentWillAutoRenew = false
+                    if case .verified(let info) = status.renewalInfo {
+                        currentWillAutoRenew = info.willAutoRenew
+                    }
+                    
+                    // Compare with previous state
+                    if let previousWillAutoRenew = previousStatuses[sku], 
+                       previousWillAutoRenew != currentWillAutoRenew {
                         
                         var purchaseMap = serializeTransaction(transaction)
                         
-                        if let renewalInfo = status.renewalInfo.verified {
+                        if case .verified(let renewalInfo) = status.renewalInfo {
                             if let renewalInfoDict = serializeRenewalInfo(.verified(renewalInfo)) {
                                 purchaseMap["renewalInfo"] = renewalInfoDict
                             }
@@ -880,7 +895,7 @@ public class ExpoIapModule: Module {
                         self.sendEvent(IapEvent.PurchaseUpdated, purchaseMap)
                         self.sendEvent(IapEvent.TransactionIapUpdated, ["transaction": purchaseMap])
                         
-                        previousStatuses[sku] = currentRenewalState
+                        previousStatuses[sku] = currentWillAutoRenew
                     }
                 }
             }

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -647,24 +647,7 @@ public class ExpoIapModule: Module {
         }
 
         AsyncFunction("getReceiptData") { () -> String? in
-            if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
-               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
-                do {
-                    let receiptData = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
-                    return receiptData.base64EncodedString(options: [])
-                } catch {
-                    throw NSError(
-                        domain: "ExpoIapModule", code: 13,
-                        userInfo: [
-                            NSLocalizedDescriptionKey:
-                                "Error reading receipt data: \(error.localizedDescription)"
-                        ])
-                }
-            } else {
-                throw NSError(
-                    domain: "ExpoIapModule", code: 14,
-                    userInfo: [NSLocalizedDescriptionKey: "App Store receipt not found"])
-            }
+            return try self.getReceiptDataInternal()
         }
         
         AsyncFunction("isTransactionVerified") { (sku: String) -> Bool in
@@ -712,23 +695,12 @@ public class ExpoIapModule: Module {
             }
             
             // Get receipt data
-            var receiptData: String? = nil
-            if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
-               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
-                do {
-                    let receiptDataRaw = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
-                    receiptData = receiptDataRaw.base64EncodedString(options: [])
-                } catch {
-                    throw NSError(
-                        domain: "ExpoIapModule", code: 13,
-                        userInfo: [NSLocalizedDescriptionKey: "Error reading receipt data: \(error.localizedDescription)"]
-                    )
-                }
-            } else {
-                throw NSError(
-                    domain: "ExpoIapModule", code: 14,
-                    userInfo: [NSLocalizedDescriptionKey: "App Store receipt not found"]
-                )
+            var receiptData: String = ""
+            do {
+                receiptData = try self.getReceiptDataInternal()
+            } catch {
+                // Continue with validation even if receipt retrieval fails
+                // Error will be reflected by empty receipt data
             }
             
             var isValid = false
@@ -752,7 +724,7 @@ public class ExpoIapModule: Module {
             
             return [
                 "isValid": isValid,
-                "receiptData": receiptData ?? "",
+                "receiptData": receiptData,
                 "jwsRepresentation": jwsRepresentation ?? "",
                 "latestTransaction": latestTransaction as Any
             ]
@@ -901,6 +873,27 @@ public class ExpoIapModule: Module {
             }
             
             self.pollingSkus.removeAll()
+        }
+    }
+    
+    private func getReceiptDataInternal() throws -> String {
+        if let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
+           FileManager.default.fileExists(atPath: appStoreReceiptURL.path) {
+            do {
+                let receiptData = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+                return receiptData.base64EncodedString(options: [])
+            } catch {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 13,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Error reading receipt data: \(error.localizedDescription)"
+                    ])
+            }
+        } else {
+            throw NSError(
+                domain: "ExpoIapModule", code: 14,
+                userInfo: [NSLocalizedDescriptionKey: "App Store receipt not found"])
         }
     }
 }

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -719,8 +719,16 @@ public class ExpoIapModule: Module {
                     let receiptDataRaw = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
                     receiptData = receiptDataRaw.base64EncodedString(options: [])
                 } catch {
-                    print("Error reading receipt data: \(error.localizedDescription)")
+                    throw NSError(
+                        domain: "ExpoIapModule", code: 13,
+                        userInfo: [NSLocalizedDescriptionKey: "Error reading receipt data: \(error.localizedDescription)"]
+                    )
                 }
+            } else {
+                throw NSError(
+                    domain: "ExpoIapModule", code: 14,
+                    userInfo: [NSLocalizedDescriptionKey: "App Store receipt not found"]
+                )
             }
             
             var isValid = false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.4-rc.3",
+  "version": "2.3.4-rc.4",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.4-rc.4",
+  "version": "2.3.4-rc.5",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.4-rc.2",
+  "version": "2.3.4-rc.3",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -79,3 +79,79 @@ export const beginRefundRequest = (sku: string): Promise<RefundRequestStatus> =>
  */
 export const showManageSubscriptions = (): Promise<null> =>
   ExpoIapModule.showManageSubscriptions();
+
+/**
+ * Get the receipt data from the iOS device.
+ * This returns the base64 encoded receipt data which can be sent to your server
+ * for verification with Apple's server.
+ * 
+ * NOTE: For proper security, always verify receipts on your server using
+ * Apple's verifyReceipt endpoint, not directly from the app.
+ * 
+ * @returns {Promise<string>} Base64 encoded receipt data
+ */
+export const getReceiptIos = (): Promise<string> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('This method is only available on iOS');
+  }
+  return ExpoIapModule.getReceiptData();
+};
+
+/**
+ * Check if a transaction is verified through StoreKit 2.
+ * StoreKit 2 performs local verification of transaction JWS signatures.
+ * 
+ * @param {string} sku The product's SKU (on iOS)
+ * @returns {Promise<boolean>} True if the transaction is verified
+ */
+export const isTransactionVerified = (sku: string): Promise<boolean> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('This method is only available on iOS');
+  }
+  return ExpoIapModule.isTransactionVerified(sku);
+};
+
+/**
+ * Get the JWS representation of a purchase for server-side verification.
+ * The JWS (JSON Web Signature) can be verified on your server using Apple's public keys.
+ * 
+ * @param {string} sku The product's SKU (on iOS)
+ * @returns {Promise<string>} JWS representation of the transaction
+ */
+export const getTransactionJws = (sku: string): Promise<string> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('This method is only available on iOS');
+  }
+  return ExpoIapModule.getTransactionJws(sku);
+};
+
+/**
+ * Validate receipt for iOS using StoreKit 2's built-in verification.
+ * Returns receipt data and verification information to help with server-side validation.
+ *
+ * NOTE: For proper security, Apple recommends verifying receipts on your server using
+ * the verifyReceipt endpoint rather than relying solely on client-side verification.
+ *
+ * @param {string} sku The product's SKU (on iOS)
+ * @returns {Promise<{
+ *   isValid: boolean;
+ *   receiptData: string;
+ *   jwsRepresentation: string;
+ *   latestTransaction?: ProductPurchase;
+ * }>}
+ */
+export const validateReceiptIos = async (
+  sku: string,
+): Promise<{
+  isValid: boolean;
+  receiptData: string;
+  jwsRepresentation: string;
+  latestTransaction?: ProductPurchase;
+}> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('This method is only available on iOS');
+  }
+
+  const result = await ExpoIapModule.validateReceiptIos(sku);
+  return result;
+};

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -99,6 +99,12 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     promotedProductsIos?: Subscription;
   }>({});
 
+  const subscriptionsRefState = useRef<SubscriptionProduct[]>([]);
+
+  useEffect(() => {
+    subscriptionsRefState.current = subscriptions;
+  }, [subscriptions]);
+
   const clearCurrentPurchase = useCallback(() => {
     setCurrentPurchase(undefined);
   }, []);
@@ -193,7 +199,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
           });
         }
 
-        if (subscriptions.some((sub) => sub.id === productId)) {
+        if (subscriptionsRefState.current.some((sub) => sub.id === productId)) {
           await getSubscriptionsInternal([productId]);
           await getAvailablePurchasesInternal();
         }
@@ -201,7 +207,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
         console.warn('Failed to refresh subscription status:', error);
       }
     },
-    [getAvailablePurchasesInternal, getSubscriptionsInternal, subscriptions],
+    [getAvailablePurchasesInternal, getSubscriptionsInternal],
   );
 
   const validateReceipt = useCallback(

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -11,6 +11,8 @@ import {
   getSubscriptions,
   requestPurchase as requestPurchaseInternal,
   sync,
+  validateReceiptIos,
+  validateReceiptAndroid,
 } from './';
 import {useCallback, useEffect, useState, useRef} from 'react';
 import {
@@ -49,6 +51,12 @@ type UseIap = {
   getProducts: (skus: string[]) => Promise<void>;
   getSubscriptions: (skus: string[]) => Promise<void>;
   requestPurchase: typeof requestPurchaseInternal;
+  validateReceipt: (sku: string, androidOptions?: {
+    packageName: string;
+    productToken: string;
+    accessToken: string;
+    isSub?: boolean;
+  }) => Promise<any>;
 };
 
 export interface UseIAPOptions {
@@ -179,6 +187,32 @@ export function useIAP(options?: UseIAPOptions): UseIap {
       console.warn('Failed to refresh subscription status:', error);
     }
   }, [getSubscriptionsInternal, getAvailablePurchasesInternal, subscriptions]);
+  const validateReceipt = useCallback(
+    async (sku: string, androidOptions?: {
+      packageName: string;
+      productToken: string;
+      accessToken: string;
+      isSub?: boolean;
+    }) => {
+      if (Platform.OS === 'ios') {
+        return await validateReceiptIos(sku);
+      } else if (Platform.OS === 'android') {
+        if (!androidOptions || !androidOptions.packageName || !androidOptions.productToken || !androidOptions.accessToken) {
+          throw new Error('Android validation requires packageName, productToken, and accessToken');
+        }
+        return await validateReceiptAndroid({
+          packageName: androidOptions.packageName,
+          productId: sku,
+          productToken: androidOptions.productToken,
+          accessToken: androidOptions.accessToken,
+          isSub: androidOptions.isSub,
+        });
+      } else {
+        throw new Error('Platform not supported');
+      }
+    },
+    [],
+  );
 
   const initIapWithSubscriptions = useCallback(async (): Promise<void> => {
     const result = await initConnection();
@@ -259,5 +293,6 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     getProducts: getProductsInternal,
     getSubscriptions: getSubscriptionsInternal,
     requestPurchase: requestPurchaseWithReset,
+    validateReceipt,
   };
 }

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -201,8 +201,9 @@ export function useIAP(options?: UseIAPOptions): UseIap {
         console.warn('Failed to refresh subscription status:', error);
       }
     },
-    [getSubscriptionsInternal, getAvailablePurchasesInternal, subscriptions],
+    [getAvailablePurchasesInternal, getSubscriptionsInternal, subscriptions],
   );
+
   const validateReceipt = useCallback(
     async (
       sku: string,

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -51,16 +51,21 @@ type UseIap = {
   getProducts: (skus: string[]) => Promise<void>;
   getSubscriptions: (skus: string[]) => Promise<void>;
   requestPurchase: typeof requestPurchaseInternal;
-  validateReceipt: (sku: string, androidOptions?: {
-    packageName: string;
-    productToken: string;
-    accessToken: string;
-    isSub?: boolean;
-  }) => Promise<any>;
+  validateReceipt: (
+    sku: string,
+    androidOptions?: {
+      packageName: string;
+      productToken: string;
+      accessToken: string;
+      isSub?: boolean;
+    },
+  ) => Promise<any>;
 };
 
 export interface UseIAPOptions {
-  onPurchaseSuccess?: (purchase: ProductPurchase | SubscriptionPurchase) => void;
+  onPurchaseSuccess?: (
+    purchase: ProductPurchase | SubscriptionPurchase,
+  ) => void;
   onPurchaseError?: (error: PurchaseError) => void;
   onSyncError?: (error: Error) => void;
 }
@@ -148,14 +153,19 @@ export function useIAP(options?: UseIAPOptions): UseIap {
         }
       }
     },
-    [currentPurchase?.id, currentPurchaseError?.productId, clearCurrentPurchase, clearCurrentPurchaseError],
+    [
+      currentPurchase?.id,
+      currentPurchaseError?.productId,
+      clearCurrentPurchase,
+      clearCurrentPurchaseError,
+    ],
   );
 
   const requestPurchaseWithReset = useCallback(
     async (requestObj: Parameters<typeof requestPurchaseInternal>[0]) => {
       clearCurrentPurchase();
       clearCurrentPurchaseError();
-      
+
       try {
         return await requestPurchaseInternal(requestObj);
       } catch (error) {
@@ -165,40 +175,56 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [clearCurrentPurchase, clearCurrentPurchaseError],
   );
 
-  const refreshSubscriptionStatus = useCallback(async (productId: string) => {
-    try {
-      if (Platform.OS === 'ios') {
-        await sync().catch((error) => {
-          // Pass the error to the developer's handler if provided
-          if (optionsRef.current?.onSyncError) {
-            optionsRef.current.onSyncError(error);
-          } else {
-            // Fallback to original behavior
-            console.warn('Sync error occurred. This might require user password:', error);
-          }
-        });
+  const refreshSubscriptionStatus = useCallback(
+    async (productId: string) => {
+      try {
+        if (Platform.OS === 'ios') {
+          await sync().catch((error) => {
+            // Pass the error to the developer's handler if provided
+            if (optionsRef.current?.onSyncError) {
+              optionsRef.current.onSyncError(error);
+            } else {
+              // Fallback to original behavior
+              console.warn(
+                'Sync error occurred. This might require user password:',
+                error,
+              );
+            }
+          });
+        }
+
+        if (subscriptions.some((sub) => sub.id === productId)) {
+          await getSubscriptionsInternal([productId]);
+          await getAvailablePurchasesInternal();
+        }
+      } catch (error) {
+        console.warn('Failed to refresh subscription status:', error);
       }
-      
-      if (subscriptions.some(sub => sub.id === productId)) {
-        await getSubscriptionsInternal([productId]);
-        await getAvailablePurchasesInternal();
-      }
-    } catch (error) {
-      console.warn('Failed to refresh subscription status:', error);
-    }
-  }, [getSubscriptionsInternal, getAvailablePurchasesInternal, subscriptions]);
+    },
+    [getSubscriptionsInternal, getAvailablePurchasesInternal, subscriptions],
+  );
   const validateReceipt = useCallback(
-    async (sku: string, androidOptions?: {
-      packageName: string;
-      productToken: string;
-      accessToken: string;
-      isSub?: boolean;
-    }) => {
+    async (
+      sku: string,
+      androidOptions?: {
+        packageName: string;
+        productToken: string;
+        accessToken: string;
+        isSub?: boolean;
+      },
+    ) => {
       if (Platform.OS === 'ios') {
         return await validateReceiptIos(sku);
       } else if (Platform.OS === 'android') {
-        if (!androidOptions || !androidOptions.packageName || !androidOptions.productToken || !androidOptions.accessToken) {
-          throw new Error('Android validation requires packageName, productToken, and accessToken');
+        if (
+          !androidOptions ||
+          !androidOptions.packageName ||
+          !androidOptions.productToken ||
+          !androidOptions.accessToken
+        ) {
+          throw new Error(
+            'Android validation requires packageName, productToken, and accessToken',
+          );
         }
         return await validateReceiptAndroid({
           packageName: androidOptions.packageName,
@@ -248,14 +274,14 @@ export function useIAP(options?: UseIAPOptions): UseIap {
       if (Platform.OS === 'ios') {
         subscriptionsRef.current.promotedProductsIos = transactionUpdatedIos(
           async (event: TransactionEvent) => {
-            if (event.transaction) {
-              setPromotedProductsIOS((prevProducts) => 
-                [...prevProducts, event.transaction!]
-              );
-              
-              if ('expirationDateIos' in event.transaction) {
-                await refreshSubscriptionStatus(event.transaction.id);
-              }
+            setPromotedProductsIOS((prevProducts) =>
+              event.transaction
+                ? [...prevProducts, event.transaction]
+                : prevProducts,
+            );
+
+            if (event.transaction && 'expirationDateIos' in event.transaction) {
+              await refreshSubscriptionStatus(event.transaction.id);
             }
           },
         );


### PR DESCRIPTION
## Overview
This PR adds receipt validation capabilities to the expo-iap library, enabling developers to validate purchases directly on iOS using StoreKit 2's built-in verification mechanisms, while maintaining the existing Android validation functionality.

## Features Added
- Added `validateReceiptIos` method that leverages StoreKit 2's verification system
- Added utility methods for more granular validation: `getReceiptData`, `isTransactionVerified`, and `getTransactionJws`
- Extended `useIAP` hook with a platform-agnostic `validateReceipt` method
- Updated example app with receipt validation demonstration

## Technical Details
- StoreKit 2 has built-in receipt validation through its VerificationResult API
- New iOS implementation returns comprehensive validation information:
  - Receipt validity status (isValid)
  - Base64 encoded receipt data for server verification
  - JWS (JSON Web Signature) representation for secure verification
  - Latest transaction details when available

## Benefits
- Simplifies purchase validation for developers
- Provides a unified validation API across both iOS and Android
- Allows both client-side validation and server-side validation options
- Takes advantage of Apple's recommended StoreKit 2 verification system

## Testing
- Validated on iOS simulator and device with test purchases
- Android validation functionality remains unchanged
- Example app updated to demonstrate both iOS and Android validation flows

This feature is particularly useful for developers who need secure verification of purchases before delivering digital content to users.