### PR TITLE
fix: return jwsRepresentationIos in getAvailableItems

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -381,8 +381,12 @@ public class ExpoIapModule: Module {
                         let transaction = try self.checkVerified(verification)
                         
                         // Debug: Log JWS representation
-                        logDebug("buyProduct JWS: exists")
-                        logDebug("buyProduct JWS length: \(verification.jwsRepresentation.count)")
+                        if let jwsRepresentation = verification.jwsRepresentation {
+                            logDebug("buyProduct JWS: exists")
+                            logDebug("buyProduct JWS length: \(jwsRepresentation.count)")
+                        } else {
+                            logDebug("buyProduct JWS: does not exist")
+                        }
                         
                         if andDangerouslyFinishTransactionAutomatically {
                             await transaction.finish()

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -761,7 +761,7 @@ public class ExpoIapModule: Module {
                     let transaction = try self.checkVerified(result)
                     self.transactions[String(transaction.id)] = transaction
                     if self.hasListeners {
-                        let serialized = serializeTransaction(transaction)
+                        let serialized = serializeTransaction(transaction, jwsRepresentationIos: result.jwsRepresentation)
                         self.sendEvent(IapEvent.PurchaseUpdated, serialized)
                         self.sendEvent(IapEvent.TransactionIapUpdated, ["transaction": serialized])
                     }
@@ -835,7 +835,7 @@ public class ExpoIapModule: Module {
                 }
                 previousStatuses[sku] = willAutoRenew
             }
-            
+
             for _ in 1...5 {
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
                 if Task.isCancelled {

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -9,6 +9,12 @@ func serializeDebug(_ s: String) -> String? {
     #endif
 }
 
+func logDebug(_ message: String) {
+    #if DEBUG
+        print("DEBUG - \(message)")
+    #endif
+}
+
 struct IapEvent {
     static let PurchaseUpdated = "purchase-updated"
     static let PurchaseError = "purchase-error"
@@ -71,10 +77,10 @@ func serializeTransaction(_ transaction: Transaction, jwsRepresentationIos: Stri
     ]
 
     if (jwsRepresentationIos != nil) {
-        print("DEBUG - serializeTransaction adding jwsRepresentationIos with length: \(jwsRepresentationIos!.count)")
+        logDebug("serializeTransaction adding jwsRepresentationIos with length: \(jwsRepresentationIos!.count)")
         purchaseMap["jwsRepresentationIos"] = jwsRepresentationIos
     } else {
-        print("DEBUG - serializeTransaction jwsRepresentationIos is nil")
+        logDebug("serializeTransaction jwsRepresentationIos is nil")
     }
     
     if #available(iOS 16.0, *) {
@@ -241,16 +247,16 @@ public class ExpoIapModule: Module {
 
             func addTransaction(transaction: Transaction, jwsRepresentationIos: String? = nil) {
                 // Debug: Log JWS representation
-                print("DEBUG - getAvailableItems JWS: \(jwsRepresentationIos != nil ? "exists" : "nil")")
+                logDebug("getAvailableItems JWS: \(jwsRepresentationIos != nil ? "exists" : "nil")")
                 if let jws = jwsRepresentationIos {
-                    print("DEBUG - getAvailableItems JWS length: \(jws.count)")
+                    logDebug("getAvailableItems JWS length: \(jws.count)")
                 }
                 
                 let serialized = serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos)
                 purchasedItemsSerialized.append(serialized)
                 
                 // Debug: Check if jwsRepresentationIos is included in serialized result
-                print("DEBUG - getAvailableItems serialized includes JWS: \(serialized["jwsRepresentationIos"] != nil)")
+                logDebug("getAvailableItems serialized includes JWS: \(serialized["jwsRepresentationIos"] != nil)")
                 
                 if alsoPublishToEventListener {
                     self.sendEvent(IapEvent.PurchaseUpdated, serialized)
@@ -375,8 +381,8 @@ public class ExpoIapModule: Module {
                         let transaction = try self.checkVerified(verification)
                         
                         // Debug: Log JWS representation
-                        print("DEBUG - buyProduct JWS: exists")
-                        print("DEBUG - buyProduct JWS length: \(verification.jwsRepresentation.count)")
+                        logDebug("buyProduct JWS: exists")
+                        logDebug("buyProduct JWS length: \(verification.jwsRepresentation.count)")
                         
                         if andDangerouslyFinishTransactionAutomatically {
                             await transaction.finish()
@@ -386,7 +392,7 @@ public class ExpoIapModule: Module {
                             let serialized = serializeTransaction(transaction, jwsRepresentationIos: verification.jwsRepresentation)
                             
                             // Debug: Check if jwsRepresentationIos is included in serialized result
-                            print("DEBUG - buyProduct serialized includes JWS: \(serialized["jwsRepresentationIos"] != nil)")
+                            logDebug("buyProduct serialized includes JWS: \(serialized["jwsRepresentationIos"] != nil)")
                             
                             self.sendEvent(IapEvent.PurchaseUpdated, serialized)
                             return serialized

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -71,7 +71,10 @@ func serializeTransaction(_ transaction: Transaction, jwsRepresentationIos: Stri
     ]
 
     if (jwsRepresentationIos != nil) {
+        print("DEBUG - serializeTransaction adding jwsRepresentationIos with length: \(jwsRepresentationIos!.count)")
         purchaseMap["jwsRepresentationIos"] = jwsRepresentationIos
+    } else {
+        print("DEBUG - serializeTransaction jwsRepresentationIos is nil")
     }
     
     if #available(iOS 16.0, *) {
@@ -237,15 +240,20 @@ public class ExpoIapModule: Module {
             var purchasedItemsSerialized: [[String: Any?]] = []
 
             func addTransaction(transaction: Transaction, jwsRepresentationIos: String? = nil) {
-                purchasedItemsSerialized.append(serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos))
-                if alsoPublishToEventListener {
-                    self.sendEvent(IapEvent.PurchaseUpdated, serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos))
+                // Debug: Log JWS representation
+                print("DEBUG - getAvailableItems JWS: \(jwsRepresentationIos != nil ? "exists" : "nil")")
+                if let jws = jwsRepresentationIos {
+                    print("DEBUG - getAvailableItems JWS length: \(jws.count)")
                 }
-            }
-
-            func addError(error: Error, errorDict: [String: String]) {
+                
+                let serialized = serializeTransaction(transaction, jwsRepresentationIos: jwsRepresentationIos)
+                purchasedItemsSerialized.append(serialized)
+                
+                // Debug: Check if jwsRepresentationIos is included in serialized result
+                print("DEBUG - getAvailableItems serialized includes JWS: \(serialized["jwsRepresentationIos"] != nil)")
+                
                 if alsoPublishToEventListener {
-                    self.sendEvent(IapEvent.PurchaseError, errorDict)
+                    self.sendEvent(IapEvent.PurchaseUpdated, serialized)
                 }
             }
 
@@ -287,7 +295,9 @@ public class ExpoIapModule: Module {
                         "message": StoreError.failedVerification.localizedDescription,
                         "productId": "unknown",
                     ]
-                    addError(error: StoreError.failedVerification, errorDict: err)
+                    if alsoPublishToEventListener {
+                        self.sendEvent(IapEvent.PurchaseError, err)
+                    }
                 } catch {
                     let err = [
                         "responseCode": IapErrors.E_UNKNOWN.rawValue,
@@ -296,10 +306,11 @@ public class ExpoIapModule: Module {
                         "message": error.localizedDescription,
                         "productId": "unknown",
                     ]
-                    addError(error: error, errorDict: err)
+                    if alsoPublishToEventListener {
+                        self.sendEvent(IapEvent.PurchaseError, err)
+                    }
                 }
             }
-
             return purchasedItemsSerialized
         }
 
@@ -362,12 +373,21 @@ public class ExpoIapModule: Module {
                     switch result {
                     case .success(let verification):
                         let transaction = try self.checkVerified(verification)
+                        
+                        // Debug: Log JWS representation
+                        print("DEBUG - buyProduct JWS: exists")
+                        print("DEBUG - buyProduct JWS length: \(verification.jwsRepresentation.count)")
+                        
                         if andDangerouslyFinishTransactionAutomatically {
                             await transaction.finish()
                             return nil
                         } else {
                             self.transactions[String(transaction.id)] = transaction
                             let serialized = serializeTransaction(transaction, jwsRepresentationIos: verification.jwsRepresentation)
+                            
+                            // Debug: Check if jwsRepresentationIos is included in serialized result
+                            print("DEBUG - buyProduct serialized includes JWS: \(serialized["jwsRepresentationIos"] != nil)")
+                            
                             self.sendEvent(IapEvent.PurchaseUpdated, serialized)
                             return serialized
                         }
@@ -458,9 +478,7 @@ public class ExpoIapModule: Module {
                 } else {
                     throw NSError(
                         domain: "ExpoIapModule", code: 4,
-                        userInfo: [
-                            NSLocalizedDescriptionKey: "Can't find entitlement for sku \(sku)"
-                        ])
+                        userInfo: [NSLocalizedDescriptionKey: "Can't find entitlement for sku \(sku)"])
                 }
             } else {
                 throw NSError(
@@ -499,10 +517,7 @@ public class ExpoIapModule: Module {
                 } else {
                     throw NSError(
                         domain: "ExpoIapModule", code: 4,
-                        userInfo: [
-                            NSLocalizedDescriptionKey:
-                                "Can't find latest transaction for sku \(sku)"
-                        ])
+                        userInfo: [NSLocalizedDescriptionKey: "Can't find latest transaction for sku \(sku)"])
                 }
             } else {
                 throw NSError(
@@ -562,17 +577,13 @@ public class ExpoIapModule: Module {
                                 "Cannot find window scene or not available on macOS"
                         ])
                 }
-                
                 // Get all subscription products before showing the management UI
                 let subscriptionSkus = await self.getAllSubscriptionProductIds()
                 self.pollingSkus = Set(subscriptionSkus)
-                
                 // Show the management UI
                 try await AppStore.showManageSubscriptions(in: windowScene)
-                
                 // Start polling for status changes
                 self.pollForSubscriptionStatusChanges()
-                
                 return true
             #else
                 throw NSError(
@@ -649,7 +660,7 @@ public class ExpoIapModule: Module {
         AsyncFunction("getReceiptData") { () -> String? in
             return try self.getReceiptDataInternal()
         }
-        
+
         AsyncFunction("isTransactionVerified") { (sku: String) -> Bool in
             guard let productStore = self.productStore else {
                 throw NSError(
@@ -669,7 +680,7 @@ public class ExpoIapModule: Module {
             }
             return false
         }
-        
+
         AsyncFunction("getTransactionJws") { (sku: String) -> String? in
             guard let productStore = self.productStore else {
                 throw NSError(
@@ -686,7 +697,7 @@ public class ExpoIapModule: Module {
                     userInfo: [NSLocalizedDescriptionKey: "Can't find transaction for sku \(sku)"])
             }
         }
-        
+
         AsyncFunction("validateReceiptIos") { (sku: String) -> [String: Any] in
             guard let productStore = self.productStore else {
                 throw NSError(
@@ -721,7 +732,7 @@ public class ExpoIapModule: Module {
                     isValid = false
                 }
             }
-            
+
             return [
                 "isValid": isValid,
                 "receiptData": receiptData,
@@ -808,7 +819,6 @@ public class ExpoIapModule: Module {
 
     private func pollForSubscriptionStatusChanges() {
         subscriptionPollingTask?.cancel()
-        
         subscriptionPollingTask = Task {
             try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
             
@@ -828,7 +838,6 @@ public class ExpoIapModule: Module {
             
             for _ in 1...5 {
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
-                
                 if Task.isCancelled {
                     return
                 }
@@ -837,7 +846,6 @@ public class ExpoIapModule: Module {
                     guard let product = await self.productStore?.getProduct(productID: sku),
                           let status = try? await product.subscription?.status.first,
                           let result = await product.latestTransaction else { continue }
-                    
                     // Try to verify the transaction
                     let transaction: Transaction
                     do {
@@ -866,12 +874,10 @@ public class ExpoIapModule: Module {
                         
                         self.sendEvent(IapEvent.PurchaseUpdated, purchaseMap)
                         self.sendEvent(IapEvent.TransactionIapUpdated, ["transaction": purchaseMap])
-                        
                         previousStatuses[sku] = currentWillAutoRenew
                     }
                 }
             }
-            
             self.pollingSkus.removeAll()
         }
     }

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -870,7 +870,8 @@ public class ExpoIapModule: Module {
                     if let previousWillAutoRenew = previousStatuses[sku], 
                        previousWillAutoRenew != currentWillAutoRenew {
                         
-                        var purchaseMap = serializeTransaction(transaction)
+                        // Use the jwsRepresentation when serializing the transaction
+                        var purchaseMap = serializeTransaction(transaction, jwsRepresentationIos: result.jwsRepresentation)
                         
                         if case .verified(let renewalInfo) = status.renewalInfo {
                             if let renewalInfoDict = serializeRenewalInfo(.verified(renewalInfo)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.5-rc.1",
+  "version": "2.3.5-rc.2",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.5-rc.2",
+  "version": "2.3.5-rc.3",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.3.4",
+  "version": "2.3.5-rc.1",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
### Related Issue

Fixes #51

### Description

This PR resolves an issue where the `jwsRepresentationIos` field was missing from the result of the `getAvailablePurchases()` function on iOS devices. This issue specifically occurred in the Sandbox environment on devices running iOS 15+ with StoreKit 2.

### Changes

* Added debug logs in the iOS native code to trace where the JWS representation was being omitted
* Improved handling of `jwsRepresentationIos` in the `getAvailableItems()` method
* Enhanced the serialization logic for JWS representation in the `serializeTransaction()` function

### How to Test

* Run the app on a physical iOS 15+ device
* Test in-app purchases in the Sandbox environment
* Verify that the `getAvailablePurchases()` result includes the `jwsRepresentationIos` field
* Confirm that the purchase validation flow works correctly

### Additional Information

This change only affects iOS devices, particularly those using StoreKit 2. Android devices are unaffected.
