### PR TITLE
add: specific permission to get merged

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="com.android.vending.BILLING"/>
 </manifest>


### PR DESCRIPTION
Additional manual configurations should be minimized. 
Expo modules permissions get merged automatically in the Android root manifest:

![image](https://github.com/user-attachments/assets/c1c913c8-b7a2-478a-b606-4b31baaa9ab7)
