### PR TITLE
refactor: export types for external usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,23 +26,7 @@ import {
 import {isProductIos} from './modules/ios';
 import {isProductAndroid} from './modules/android';
 
-export type {
-  AndroidPlatform,
-  ChangeEventPayload,
-  IosPlatform,
-  Product,
-  ProductBase,
-  ProductPurchase,
-  ProductType,
-  Purchase,
-  PurchaseBase,
-  PurchaseResult,
-  RequestPurchaseProps,
-  RequestSubscriptionProps,
-  SubscriptionProduct,
-  SubscriptionPurchase,
-} from './ExpoIap.types';
-export {ErrorCode, PurchaseError} from './ExpoIap.types';
+export * from './ExpoIap.types';
 export * from './modules/android';
 export * from './modules/ios';
 


### PR DESCRIPTION
## Summary
Export TypeScript types, enums, and classes to enable developers to properly type their IAP implementations when using expo-iap.
- Export type definitions
- Export ErrorCode enum and PurchaseError class for error handling


## Problem
Developers cannot import types, enums, or error classes from expo-iap, making it difficult to

<img width="617" alt="image" src="https://github.com/user-attachments/assets/a9c5bb5e-bd4a-4366-9827-b0998dbdcbb8" />


## environment
- expo-iap@2.4.0
