### PR TITLE
fix(ios): enable jsonRepresentation in release builds

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -123,8 +123,7 @@ func serializeProduct(_ p: Product) -> [String: Any?] {
         "id": p.id,
         "title": p.displayName,
         "isFamilyShareable": p.isFamilyShareable,
-        "jsonRepresentation": serializeDebug(
-            String(data: p.jsonRepresentation, encoding: .utf8) ?? ""),
+        "jsonRepresentation": String(data: p.jsonRepresentation, encoding: .utf8),
         "price": p.price,
         "subscription": p.subscription,
         "type": p.type,


### PR DESCRIPTION
## Problem
The `jsonRepresentation` field in iOS product serialization was wrapped with `serializeDebug()`, causing it to return `null` in release builds. This prevented access to critical subscription metadata like free trial duration, introductory pricing, and other subscription details that are essential for app functionality.

## Solution
- Removed `serializeDebug()` wrapper from `jsonRepresentation` field in `serializeProduct()` function
- `jsonRepresentation` now returns the actual JSON string in both debug and release builds
- Kept `serializeDebug()` for `debugDescription` field as it contains internal implementation details

## Why this change is safe
- `jsonRepresentation` is an official Apple API that contains public product metadata
- This data is meant to be consumed by apps to display subscription information
- No sensitive user data or internal implementation details are exposed
- Android builds already provide similar metadata in all build types

## Impact
- ✅ Free trial duration now accessible in iOS release builds
- ✅ Subscription metadata available for proper UI display
- ✅ Cross-platform consistency between iOS and Android
- ✅ No breaking changes to existing API

## Testing
- [x] Verified in development builds (existing functionality)
- [x] Verified in release builds (new functionality)
- [x] Confirmed no sensitive data exposure

Closes #57