### PR TITLE
Fix incorrect use of skus for iOS in example app

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -231,7 +231,7 @@ export default function App() {
                       title="Buy"
                       onPress={() => {
                         requestPurchase({
-                          request: {skus: [item.id]},
+                          request: {sku: item.id},
                         });
                       }}
                     />


### PR DESCRIPTION
This PR fixes a minor issue in the example app where requestPurchase uses the skus field for iOS, which is not valid.

• Updated product purchase requests on iOS to use sku instead of skus