### PR TITLE
Fix the broken documentation link in the documentation.

### DIFF
--- a/iap.md
+++ b/iap.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-`expo-iap` is compatible with [Expo SDK](https://expo.dev) 51+ and supports both managed workflows and React Native CLI projects. Official documentation is in progress for SDK inclusion (see [Expo IAP Documentation](link-to-docs)).
+`expo-iap` is compatible with [Expo SDK](https://expo.dev) 51+ and supports both managed workflows and React Native CLI projects. Official documentation is in progress for SDK inclusion (see [Expo IAP Documentation](https://github.com/hyochan/expo-iap/blob/main/iap.md#expo-iap-documentation)).
 
 ### Add the Package
 


### PR DESCRIPTION
Removed "link-to-docs" with actual link to docs. I believe "link-to-docs" was just a placeholder which was redirecting to 404.