### PR TITLE
fix(ios): cast originalTransactionIdentifierIos to string

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -56,7 +56,7 @@ func serializeTransaction(_ transaction: Transaction, jwsRepresentationIos: Stri
 
         "quantityIos": transaction.purchasedQuantity,
         "originalTransactionDateIos": transaction.originalPurchaseDate.timeIntervalSince1970 * 1000,
-        "originalTransactionIdentifierIos": transaction.originalID,
+        "originalTransactionIdentifierIos": String(transaction.originalID),
         "appAccountToken": transaction.appAccountToken?.uuidString,
 
         "appBundleIdIos": transaction.appBundleID,


### PR DESCRIPTION
For consistency with the typings and `transactionId`.

StoreKit [Transaction.originalID](https://developer.apple.com/documentation/storekit/transaction/originalid) returns as a UInt64, however the typings show that `originalTransactionIdentifierIos` returns as a string:

https://github.com/hyochan/expo-iap/blob/ca7c409ec4ecf3c7ae000c1537b015df9af06df5/src/types/ExpoIapIos.types.ts#L107-L112

Either we need to update the typings or update the Swift file. 

Note that this wasn't compiled or tested. I'm using the current version of expo-iap and wrapping the value with `String(purchase.originalTransactionId)` on the JS side.