### PR TITLE
fix(ios): actually return subscription data and fix typescript taps

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -113,6 +113,47 @@ func serializeTransaction(_ transaction: Transaction, jwsRepresentationIos: Stri
     return purchaseMap
 }
 
+func getPeriodIos(_ unit: Product.SubscriptionPeriod.Unit) -> String {
+    return switch (unit) {
+    case .day: "DAY"
+    case .week: "WEEK"
+    case .month: "MONTH"
+    case .year: "YEAR"
+    default: "DAY"
+    }
+}
+
+func serializeOffer(_ offer: Product.SubscriptionOffer?) -> [String: Any?]? {
+    guard let offer = offer else { return nil }
+    
+    return [
+        "id": offer.id,
+        "period": [
+            "unit":getPeriodIos(offer.period.unit),
+            "value": offer.period.value
+        ],
+        "periodCount": offer.periodCount,
+        "paymentMode": offer.paymentMode.rawValue,
+        "type": offer.type.rawValue,
+        "price": offer.price,
+        "displayPrice": offer.displayPrice,
+    ]
+}
+
+func serializeSubscription(_ s: Product.SubscriptionInfo?) -> [String: Any?]? {
+    guard let s = s else { return nil }
+    return [
+        "introductoryOffer": serializeOffer(s.introductoryOffer),
+        "promotionalOffers": s.promotionalOffers.map(serializeOffer),
+        "subscriptionGroupID": s.subscriptionGroupID,
+        "subscriptionPeriod": [
+            "unit":getPeriodIos(s.subscriptionPeriod.unit),
+            "value": s.subscriptionPeriod.value
+        ],
+    ]
+
+}
+
 @available(iOS 15.0, *)
 func serializeProduct(_ p: Product) -> [String: Any?] {
     return [
@@ -125,7 +166,7 @@ func serializeProduct(_ p: Product) -> [String: Any?] {
         "isFamilyShareable": p.isFamilyShareable,
         "jsonRepresentation": String(data: p.jsonRepresentation, encoding: .utf8),
         "price": p.price,
-        "subscription": p.subscription,
+        "subscription": serializeSubscription(p.subscription),
         "type": p.type,
         "currency": p.priceFormatStyle.currencyCode,
         "platform": "ios",
@@ -204,6 +245,11 @@ public class ExpoIapModule: Module {
         Function("initConnection") { () -> Bool in
             self.productStore = ProductStore()
             return AppStore.canMakePayments
+        }
+
+        AsyncFunction("getStorefront") {
+            let storefront = await Storefront.current
+            return storefront?.countryCode
         }
 
         AsyncFunction("getItems") { (skus: [String]) -> [[String: Any?]?] in

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -7,7 +7,10 @@ type SubscriptionOffer = {
   displayPrice: string;
   id: string;
   paymentMode: PaymentMode;
-  period: SubscriptionIosPeriod;
+  period: {
+    unit: SubscriptionIosPeriod;
+    value: number;
+  };
   periodCount: number;
   price: number;
   type: 'introductory' | 'promotional';
@@ -17,7 +20,10 @@ type SubscriptionInfo = {
   introductoryOffer?: SubscriptionOffer;
   promotionalOffers?: SubscriptionOffer[];
   subscriptionGroupID: string;
-  subscriptionPeriod: SubscriptionIosPeriod;
+  subscriptionPeriod: {
+    unit: SubscriptionIosPeriod;
+    value: number;
+  };
 };
 
 export type ProductIos = ProductBase & {


### PR DESCRIPTION
Swift classes are not serialized by expo modules. Hence they should be manually serialized to be provided to the typescript 