### PR TITLE
feat(ios): add getAppTransaction support for iOS 16.0+

### DIFF
--- a/docs/docs/api/methods/core-methods.md
+++ b/docs/docs/api/methods/core-methods.md
@@ -138,13 +138,13 @@ const fetchAppTransaction = async () => {
 };
 ```
 
-**Returns:** `Promise<AppTransaction | null>` - Returns the app transaction information or null if not available.
+**Returns:** `Promise<AppTransactionIOS | null>` - Returns the app transaction information or null if not available.
 
 **Platform:** iOS 16.0+ only
 
-**AppTransaction Interface:**
+**AppTransactionIOS Interface:**
 ```typescript
-interface AppTransaction {
+interface AppTransactionIOS {
   appTransactionID: string;
   originalAppAccountToken?: string;
   originalPurchaseDate: number; // milliseconds since epoch

--- a/docs/docs/api/methods/core-methods.md
+++ b/docs/docs/api/methods/core-methods.md
@@ -115,6 +115,46 @@ const fetchStorefront = async () => {
 
 **Note:** This is useful for region-specific pricing, content, or features.
 
+## getAppTransaction()
+
+Gets app transaction information for iOS apps (iOS 16.0+). AppTransaction represents the initial purchase that unlocked the app, useful for premium apps or apps that were previously paid.
+
+```tsx
+import {getAppTransaction} from 'expo-iap';
+
+const fetchAppTransaction = async () => {
+  try {
+    const appTransaction = await getAppTransaction();
+    if (appTransaction) {
+      console.log('App Transaction ID:', appTransaction.appTransactionID);
+      console.log('Original Purchase Date:', new Date(appTransaction.originalPurchaseDate));
+      console.log('Device Verification:', appTransaction.deviceVerification);
+    } else {
+      console.log('No app transaction found (app may be free)');
+    }
+  } catch (error) {
+    console.error('Failed to get app transaction:', error);
+  }
+};
+```
+
+**Returns:** `Promise<AppTransaction | null>` - Returns the app transaction information or null if not available.
+
+**Platform:** iOS 16.0+ only
+
+**AppTransaction Interface:**
+```typescript
+interface AppTransaction {
+  appTransactionID: string;
+  originalAppAccountToken?: string;
+  originalPurchaseDate: number; // milliseconds since epoch
+  deviceVerification: string;
+  deviceVerificationNonce: string;
+}
+```
+
+**Note:** This is useful for verifying that a user legitimately purchased your app. The device verification data can be sent to your server for validation.
+
 ## getProducts()
 
 Fetches product information from the store.

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -255,6 +255,28 @@ public class ExpoIapModule: Module {
             return storefront?.countryCode
         }
 
+        AsyncFunction("getAppTransaction") { () async throws -> [String: Any?]? in
+            if #available(iOS 16.0, *) {
+                guard let appTransaction = try await AppTransaction.shared else {
+                    return nil
+                }
+                
+                return [
+                    "appTransactionID": appTransaction.appAppleId,
+                    "originalAppAccountToken": appTransaction.originalAppAccountToken,
+                    "originalPurchaseDate": appTransaction.originalPurchaseDate.timeIntervalSince1970 * 1000,
+                    "deviceVerification": appTransaction.deviceVerification.base64EncodedString(),
+                    "deviceVerificationNonce": appTransaction.deviceVerificationNonce.uuidString
+                ]
+            } else {
+                throw Exception(
+                    name: "ExpoIapModule",
+                    description: "getAppTransaction requires iOS 16.0 or later",
+                    code: IapErrorCode.featureNotSupported
+                )
+            }
+        }
+
         AsyncFunction("getItems") { (skus: [String]) -> [[String: Any?]?] in
             guard let productStore = self.productStore else {
                 throw Exception(name: "ExpoIapModule", description: "Connection not initialized", code: IapErrorCode.notPrepared)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {isProductAndroid} from './modules/android';
 export * from './ExpoIap.types';
 export * from './modules/android';
 export * from './modules/ios';
+export type {AppTransaction} from './types/ExpoIapIos.types';
 
 // Get the native constant value
 export const PI = ExpoIapModule.PI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {isProductAndroid} from './modules/android';
 export * from './ExpoIap.types';
 export * from './modules/android';
 export * from './modules/ios';
-export type {AppTransaction} from './types/ExpoIapIos.types';
+export type {AppTransactionIOS} from './types/ExpoIapIos.types';
 
 // Get the native constant value
 export const PI = ExpoIapModule.PI;

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -6,7 +6,7 @@ import {
   Purchase,
   SubscriptionPurchase,
 } from '../ExpoIap.types';
-import type {ProductStatusIos, AppTransaction} from '../types/ExpoIapIos.types';
+import type {ProductStatusIos, AppTransactionIOS} from '../types/ExpoIapIos.types';
 import ExpoIapModule from '../ExpoIapModule';
 
 export type TransactionEvent = {
@@ -225,10 +225,10 @@ export const presentCodeRedemptionSheet = (): Promise<boolean> => {
  * Get app transaction information (iOS 16.0+).
  * AppTransaction represents the initial purchase that unlocked the app.
  * 
- * @returns {Promise<AppTransaction | null>} The app transaction information or null if not available
+ * @returns {Promise<AppTransactionIOS | null>} The app transaction information or null if not available
  * @throws {Error} If called on non-iOS platform or iOS version < 16.0
  */
-export const getAppTransaction = (): Promise<AppTransaction | null> => {
+export const getAppTransaction = (): Promise<AppTransactionIOS | null> => {
   if (Platform.OS !== 'ios') {
     throw new Error('This method is only available on iOS');
   }

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -6,7 +6,7 @@ import {
   Purchase,
   SubscriptionPurchase,
 } from '../ExpoIap.types';
-import type {ProductStatusIos} from '../types/ExpoIapIos.types';
+import type {ProductStatusIos, AppTransaction} from '../types/ExpoIapIos.types';
 import ExpoIapModule from '../ExpoIapModule';
 
 export type TransactionEvent = {
@@ -219,4 +219,18 @@ export const presentCodeRedemptionSheet = (): Promise<boolean> => {
     throw new Error('This method is only available on iOS');
   }
   return ExpoIapModule.presentCodeRedemptionSheet();
+};
+
+/**
+ * Get app transaction information (iOS 16.0+).
+ * AppTransaction represents the initial purchase that unlocked the app.
+ * 
+ * @returns {Promise<AppTransaction | null>} The app transaction information or null if not available
+ * @throws {Error} If called on non-iOS platform or iOS version < 16.0
+ */
+export const getAppTransaction = (): Promise<AppTransaction | null> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('This method is only available on iOS');
+  }
+  return ExpoIapModule.getAppTransaction();
 };

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -140,3 +140,11 @@ export type ProductPurchaseIos = PurchaseBase & {
   currencyIos?: string;
   jwsRepresentationIos?: string;
 };
+
+export type AppTransaction = {
+  appTransactionID: string;
+  originalAppAccountToken?: string;
+  originalPurchaseDate: number;
+  deviceVerification: string;
+  deviceVerificationNonce: string;
+};

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -141,7 +141,7 @@ export type ProductPurchaseIos = PurchaseBase & {
   jwsRepresentationIos?: string;
 };
 
-export type AppTransaction = {
+export type AppTransactionIOS = {
   appTransactionID: string;
   originalAppAccountToken?: string;
   originalPurchaseDate: number;


### PR DESCRIPTION
- Add AppTransaction TypeScript type definition
- Implement native getAppTransaction method in Swift module
- Export getAppTransaction function from ios module
- Add comprehensive documentation for the new API
- Fix appTransactionID field name to match Apple's API

Port of [react-native-iap PR #2969](https://github.com/hyochan/react-native-iap/pull/2969)