### PR TITLE
fix: update purchase history method naming to plural form

### DIFF
--- a/docs/blog/2025-07-21-v2-6-0-release.md
+++ b/docs/blog/2025-07-21-v2-6-0-release.md
@@ -91,7 +91,19 @@ Check out the new [iOS Subscription Offers Guide](/docs/guides/ios-subscription-
 
 ## ⚠️ Breaking Changes
 
-### Optional Subscription Field
+### 1. Method Naming Update
+
+To improve consistency, we've updated the purchase history method naming:
+
+- **Deprecated**: `getPurchaseHistory()` (singular)
+- **New**: `getPurchaseHistories()` (plural)
+
+The `useIAP` hook already uses the plural form:
+```typescript
+const { purchaseHistories, getPurchaseHistories } = useIAP();
+```
+
+### 2. Optional Subscription Field
 
 The `subscription` field in `ProductIos` is now optional to reflect that not all iOS products have subscription information:
 

--- a/docs/docs/api/methods/core-methods.md
+++ b/docs/docs/api/methods/core-methods.md
@@ -454,23 +454,25 @@ const restorePurchases = async () => {
 
 **Returns:** `Promise<Purchase[]>`
 
-## getPurchaseHistory()
+## getPurchaseHistories()
 
 Retrieves purchase history for the user.
 
 ```tsx
-import {getPurchaseHistory} from 'expo-iap';
+import {getPurchaseHistories} from 'expo-iap';
 
 const fetchPurchaseHistory = async () => {
   try {
-    const history = await getPurchaseHistory();
-    console.log('Purchase history:', history);
-    return history;
+    const histories = await getPurchaseHistories();
+    console.log('Purchase histories:', histories);
+    return histories;
   } catch (error) {
-    console.error('Failed to fetch purchase history:', error);
+    console.error('Failed to fetch purchase histories:', error);
   }
 };
 ```
+
+**Note:** The previous `getPurchaseHistory` (singular) function is deprecated and will be removed in version 3.0.0. Please use `getPurchaseHistories` (plural) instead.
 
 **Returns:** `Promise<Purchase[]>`
 

--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -169,6 +169,28 @@ interface UseIAPOptions {
   }, [currentPurchaseError]);
   ```
 
+#### purchaseHistories
+
+- **Type**: `ProductPurchase[]`
+- **Description**: Array of purchase history items
+- **Example**:
+  ```tsx
+  purchaseHistories.map((purchase) => (
+    <PurchaseHistoryItem key={purchase.transactionId} purchase={purchase} />
+  ));
+  ```
+
+#### availablePurchases
+
+- **Type**: `ProductPurchase[]`
+- **Description**: Array of available purchases (restorable items)
+- **Example**:
+  ```tsx
+  availablePurchases.map((purchase) => (
+    <RestorableItem key={purchase.transactionId} purchase={purchase} />
+  ));
+  ```
+
 ### Methods
 
 #### getProducts
@@ -230,6 +252,38 @@ interface UseIAPOptions {
       });
     } catch (error) {
       console.error('Purchase request failed:', error);
+    }
+  };
+  ```
+
+#### getPurchaseHistories
+
+- **Type**: `() => Promise<void>`
+- **Description**: Fetch purchase history from the store
+- **Example**:
+  ```tsx
+  const fetchPurchaseHistory = async () => {
+    try {
+      await getPurchaseHistories();
+      console.log('Purchase history fetched:', purchaseHistories);
+    } catch (error) {
+      console.error('Failed to fetch purchase history:', error);
+    }
+  };
+  ```
+
+#### getAvailablePurchases
+
+- **Type**: `() => Promise<void>`
+- **Description**: Fetch available purchases (restorable items) from the store
+- **Example**:
+  ```tsx
+  const restorePurchases = async () => {
+    try {
+      await getAvailablePurchases();
+      console.log('Available purchases:', availablePurchases);
+    } catch (error) {
+      console.error('Failed to fetch available purchases:', error);
     }
   };
   ```

--- a/docs/docs/guides/migration.md
+++ b/docs/docs/guides/migration.md
@@ -170,14 +170,14 @@ const {
   connected,
   products,
   subscriptions,
-  purchaseHistory,        // Note: singular form
+  purchaseHistories,      // Note: plural form in expo-iap
   availablePurchases,
   currentPurchase,
   currentPurchaseError,
   finishTransaction,
   getProducts,
   getSubscriptions,
-  getPurchaseHistory,     // Method: singular form, not getPurchaseHistories
+  getPurchaseHistories,   // Method: plural form in expo-iap v2.6.0+
   getAvailablePurchases,
   // Additional methods and better typing
 } = useIAP();
@@ -224,16 +224,19 @@ useEffect(() => {
 
 ### Method Naming Differences
 
-While expo-iap aims to maintain compatibility with react-native-iap, there are some intentional naming improvements:
+expo-iap maintains API compatibility with react-native-iap, with the following naming conventions:
 
-| react-native-iap | expo-iap | Reason |
+| react-native-iap | expo-iap | Status |
 |-----------------|----------|---------|
-| `getPurchaseHistory()` | `getPurchaseHistory()` | ✅ Same |
-| `purchaseHistory` (in hook) | `purchaseHistory` | ✅ Same |
+| `getPurchaseHistory()` | `getPurchaseHistories()` | ✅ Updated in v2.6.0 |
+| `purchaseHistory` (in hook) | `purchaseHistories` | ✅ Plural form |
 | `getAvailablePurchases()` | `getAvailablePurchases()` | ✅ Same |
 | `availablePurchases` (in hook) | `availablePurchases` | ✅ Same |
 
-**Note:** Despite what some documentation might suggest, expo-iap uses the singular form `getPurchaseHistory` (not `getPurchaseHistories`) to match react-native-iap's API.
+**⚠️ Breaking Change in v2.6.0:** 
+- `getPurchaseHistory()` (singular) is now deprecated
+- Use `getPurchaseHistories()` (plural) instead
+- The hook already uses `purchaseHistories` (plural)
 
 ### Method Signatures
 
@@ -244,7 +247,7 @@ Most method signatures remain the same, but with improved TypeScript definitions
 await getProducts({skus: ['product1', 'product2']});
 await requestPurchase({sku: 'product_id'});
 await finishTransaction({purchase});
-await getPurchaseHistory(); // Note: singular form, not getPurchaseHistories
+await getPurchaseHistories(); // Note: plural form in expo-iap v2.6.0+
 ```
 
 ### New Methods

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,26 @@ export async function endConnection(): Promise<boolean> {
   return ExpoIapModule.endConnection();
 }
 
+/**
+ * @deprecated Use `getPurchaseHistories` instead. This function will be removed in version 3.0.0.
+ */
 export const getPurchaseHistory = ({
+  alsoPublishToEventListener = false,
+  onlyIncludeActiveItems = false,
+}: {
+  alsoPublishToEventListener?: boolean;
+  onlyIncludeActiveItems?: boolean;
+} = {}): Promise<ProductPurchase[]> => {
+  console.warn(
+    "`getPurchaseHistory` is deprecated. Use `getPurchaseHistories` instead. This function will be removed in version 3.0.0.",
+  );
+  return getPurchaseHistories({
+    alsoPublishToEventListener,
+    onlyIncludeActiveItems,
+  });
+};
+
+export const getPurchaseHistories = ({
   alsoPublishToEventListener = false,
   onlyIncludeActiveItems = false,
 }: {

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -5,7 +5,7 @@ import {
   purchaseUpdatedListener,
   getProducts,
   getAvailablePurchases,
-  getPurchaseHistory,
+  getPurchaseHistories,
   finishTransaction as finishTransactionInternal,
   getSubscriptions,
   requestPurchase as requestPurchaseInternal,
@@ -182,7 +182,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   }, []);
 
   const getPurchaseHistoriesInternal = useCallback(async (): Promise<void> => {
-    setPurchaseHistories(await getPurchaseHistory());
+    setPurchaseHistories(await getPurchaseHistories());
   }, []);
 
   const finishTransaction = useCallback(


### PR DESCRIPTION
## Summary

This PR updates the purchase history method naming to use the plural form for better consistency with the `useIAP` hook.

## Changes

- ✅ Add new `getPurchaseHistories()` function (plural)
- ✅ Deprecate `getPurchaseHistory()` function (singular) with warning
- ✅ Update `useIAP` hook to use `getPurchaseHistories` internally
- ✅ Update all documentation to reflect the naming change
- ✅ Add deprecation notices in docs

## Breaking Changes

⚠️ `getPurchaseHistory()` is now deprecated and will be removed in version 3.0.0. Please use `getPurchaseHistories()` instead.

## Migration

### Before
```typescript
import { getPurchaseHistory } from 'expo-iap';
const history = await getPurchaseHistory();
```

### After
```typescript
import { getPurchaseHistories } from 'expo-iap';
const histories = await getPurchaseHistories();
```

### Using the hook (no change needed)
```typescript
const { purchaseHistories, getPurchaseHistories } = useIAP();
```

## Related Issues

Addresses #100 - Clarifies the naming convention and makes it consistent throughout the library.

## Test Plan

- [x] Existing code using `getPurchaseHistory()` still works with deprecation warning
- [x] New `getPurchaseHistories()` function works correctly
- [x] `useIAP` hook continues to work with no breaking changes
- [x] Documentation is clear about the naming convention