### PR TITLE
test: add tests for purchase history naming convention

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'expo-module',
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/__tests__/**',
+    '!src/ExpoIapModule.ts', // Native module stub
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 50,
+      lines: 50,
+      statements: 50,
+    },
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,2 @@
+// Jest setup file
+// Add any global test setup here

--- a/package.json
+++ b/package.json
@@ -41,13 +41,18 @@
   "homepage": "https://github.com/hyochan#readme",
   "dependencies": {},
   "devDependencies": {
+    "@testing-library/react-hooks": "^8.0.1",
+    "@types/jest": "^29.5.12",
     "@types/react": "~19.1.7",
     "eslint": "8.57.0",
     "eslint-config-expo": "^9.2.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
     "expo-module-scripts": "^4.1.7",
-    "expo-modules-core": "^2.4.0"
+    "expo-modules-core": "^2.4.0",
+    "jest": "^29.7.0",
+    "react-test-renderer": "18.2.0",
+    "ts-jest": "^29.1.2"
   },
   "peerDependencies": {
     "expo": "*",

--- a/src/__tests__/README.md
+++ b/src/__tests__/README.md
@@ -1,0 +1,45 @@
+# expo-iap Tests
+
+This directory contains tests for the expo-iap library, with a focus on the purchase history naming convention changes introduced in v2.6.0.
+
+## Test Files
+
+### purchaseHistory.test.ts
+Tests for the purchase history API methods:
+- `getPurchaseHistory()` - Deprecated method that should show a warning
+- `getPurchaseHistories()` - New plural method that replaces the deprecated one
+
+Key test cases:
+- Deprecation warning is shown when using the old method
+- The deprecated method still works by calling the new method internally
+- Platform-specific implementations (iOS and Android)
+- Default parameter handling
+
+### useIap.test.ts
+Tests for the useIAP React hook:
+- Ensures the hook uses `purchaseHistories` (plural) in its state
+- Ensures the hook exposes `getPurchaseHistories()` method (plural)
+- Verifies the deprecated singular forms are not exposed
+- Tests initialization and cleanup behavior
+
+## Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm test -- --watch
+
+# Run tests with coverage
+npm test -- --coverage
+```
+
+## Naming Convention
+
+As of v2.6.0, the library uses plural forms for consistency:
+- State: `purchaseHistories` (not `purchaseHistory`)
+- Method: `getPurchaseHistories()` (not `getPurchaseHistory()`)
+- Hook return: `{ purchaseHistories, getPurchaseHistories }`
+
+The singular form `getPurchaseHistory()` is deprecated and will be removed in v3.0.0.

--- a/src/__tests__/purchaseHistory.test.ts
+++ b/src/__tests__/purchaseHistory.test.ts
@@ -1,0 +1,156 @@
+import { getPurchaseHistory, getPurchaseHistories } from '../index';
+import ExpoIapModule from '../ExpoIapModule';
+import { Platform } from 'react-native';
+
+// Mock the console.warn
+const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+
+// Mock ExpoIapModule
+jest.mock('../ExpoIapModule', () => ({
+  getAvailableItems: jest.fn(),
+  getPurchaseHistoryByType: jest.fn(),
+}));
+
+// Mock Platform
+jest.mock('react-native', () => ({
+  Platform: {
+    select: jest.fn(),
+  },
+}));
+
+describe('Purchase History API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConsoleWarn.mockClear();
+  });
+
+  afterAll(() => {
+    mockConsoleWarn.mockRestore();
+  });
+
+  describe('getPurchaseHistory (deprecated)', () => {
+    it('should log deprecation warning when called', async () => {
+      // Setup
+      const mockPlatformSelect = Platform.select as jest.Mock;
+      mockPlatformSelect.mockReturnValue(() => Promise.resolve([]));
+
+      // Act
+      await getPurchaseHistory();
+
+      // Assert
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '`getPurchaseHistory` is deprecated. Use `getPurchaseHistories` instead. This function will be removed in version 3.0.0.'
+      );
+    });
+
+    it('should call getPurchaseHistories internally', async () => {
+      // Setup
+      const mockPlatformSelect = Platform.select as jest.Mock;
+      const mockIosImplementation = jest.fn().mockResolvedValue([]);
+      mockPlatformSelect.mockReturnValue(mockIosImplementation);
+
+      // Act
+      await getPurchaseHistory({
+        alsoPublishToEventListener: true,
+        onlyIncludeActiveItems: true,
+      });
+
+      // Assert
+      expect(mockPlatformSelect).toHaveBeenCalled();
+      // The function should be called via getPurchaseHistories
+      expect(mockIosImplementation).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPurchaseHistories', () => {
+    it('should NOT log deprecation warning when called', async () => {
+      // Setup
+      const mockPlatformSelect = Platform.select as jest.Mock;
+      mockPlatformSelect.mockReturnValue(() => Promise.resolve([]));
+
+      // Act
+      await getPurchaseHistories();
+
+      // Assert
+      expect(mockConsoleWarn).not.toHaveBeenCalled();
+    });
+
+    describe('iOS', () => {
+      beforeEach(() => {
+        const mockPlatformSelect = Platform.select as jest.Mock;
+        mockPlatformSelect.mockImplementation((options) => options.ios);
+      });
+
+      it('should call getAvailableItems on iOS', async () => {
+        // Setup
+        const mockItems = [
+          { id: 'item1', transactionId: 'tx1' },
+          { id: 'item2', transactionId: 'tx2' },
+        ];
+        (ExpoIapModule.getAvailableItems as jest.Mock).mockResolvedValue(mockItems);
+
+        // Act
+        const result = await getPurchaseHistories({
+          alsoPublishToEventListener: true,
+          onlyIncludeActiveItems: false,
+        });
+
+        // Assert
+        expect(ExpoIapModule.getAvailableItems).toHaveBeenCalledWith(true, false);
+        expect(result).toEqual(mockItems);
+      });
+
+      it('should use default parameters on iOS', async () => {
+        // Setup
+        (ExpoIapModule.getAvailableItems as jest.Mock).mockResolvedValue([]);
+
+        // Act
+        await getPurchaseHistories();
+
+        // Assert
+        expect(ExpoIapModule.getAvailableItems).toHaveBeenCalledWith(false, false);
+      });
+    });
+
+    describe('Android', () => {
+      beforeEach(() => {
+        const mockPlatformSelect = Platform.select as jest.Mock;
+        mockPlatformSelect.mockImplementation((options) => options.android);
+      });
+
+      it('should call getPurchaseHistoryByType for both inapp and subs on Android', async () => {
+        // Setup
+        const mockProducts = [{ id: 'product1', purchaseToken: 'token1' }];
+        const mockSubscriptions = [{ id: 'sub1', purchaseToken: 'token2' }];
+        
+        (ExpoIapModule.getPurchaseHistoryByType as jest.Mock)
+          .mockResolvedValueOnce(mockProducts)
+          .mockResolvedValueOnce(mockSubscriptions);
+
+        // Act
+        const result = await getPurchaseHistories();
+
+        // Assert
+        expect(ExpoIapModule.getPurchaseHistoryByType).toHaveBeenCalledTimes(2);
+        expect(ExpoIapModule.getPurchaseHistoryByType).toHaveBeenNthCalledWith(1, 'inapp');
+        expect(ExpoIapModule.getPurchaseHistoryByType).toHaveBeenNthCalledWith(2, 'subs');
+        expect(result).toEqual([...mockProducts, ...mockSubscriptions]);
+      });
+    });
+
+    describe('Unsupported Platform', () => {
+      beforeEach(() => {
+        const mockPlatformSelect = Platform.select as jest.Mock;
+        mockPlatformSelect.mockReturnValue(null);
+      });
+
+      it('should return empty array for unsupported platforms', async () => {
+        // Act
+        const result = await getPurchaseHistories();
+
+        // Assert
+        expect(result).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/__tests__/useIap.test.ts
+++ b/src/__tests__/useIap.test.ts
@@ -1,0 +1,162 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useIAP } from '../useIap';
+import * as IapModule from '../index';
+import { Platform } from 'react-native';
+
+// Mock the IAP module
+jest.mock('../index', () => ({
+  initConnection: jest.fn().mockResolvedValue(true),
+  endConnection: jest.fn(),
+  purchaseUpdatedListener: jest.fn(),
+  purchaseErrorListener: jest.fn(),
+  getProducts: jest.fn().mockResolvedValue([]),
+  getSubscriptions: jest.fn().mockResolvedValue([]),
+  getAvailablePurchases: jest.fn().mockResolvedValue([]),
+  getPurchaseHistories: jest.fn().mockResolvedValue([]),
+  finishTransaction: jest.fn().mockResolvedValue(true),
+  requestPurchase: jest.fn().mockResolvedValue({}),
+}));
+
+// Mock Platform
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+  },
+}));
+
+// Mock expo-modules-core
+jest.mock('expo-modules-core', () => ({
+  EventSubscription: jest.fn(),
+}));
+
+describe('useIAP Hook', () => {
+  let mockRemove: jest.Mock;
+  let mockListeners: {
+    purchaseUpdate?: { remove: jest.Mock };
+    purchaseError?: { remove: jest.Mock };
+    promotedProductsIos?: { remove: jest.Mock };
+  };
+
+  beforeEach(() => {
+    mockRemove = jest.fn();
+    mockListeners = {
+      purchaseUpdate: { remove: mockRemove },
+      purchaseError: { remove: mockRemove },
+      promotedProductsIos: { remove: mockRemove },
+    };
+
+    // Setup listener mocks
+    (IapModule.purchaseUpdatedListener as jest.Mock).mockReturnValue(mockListeners.purchaseUpdate);
+    (IapModule.purchaseErrorListener as jest.Mock).mockReturnValue(mockListeners.purchaseError);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Purchase History Naming', () => {
+    it('should expose purchaseHistories (plural) in the hook return value', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      // Check that the hook exposes purchaseHistories (plural)
+      expect(result.current).toHaveProperty('purchaseHistories');
+      expect(result.current.purchaseHistories).toEqual([]);
+    });
+
+    it('should expose getPurchaseHistories (plural) method', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      // Check that the hook exposes getPurchaseHistories (plural)
+      expect(result.current).toHaveProperty('getPurchaseHistories');
+      expect(typeof result.current.getPurchaseHistories).toBe('function');
+    });
+
+    it('should call getPurchaseHistories (plural) from the module', async () => {
+      const mockHistories = [
+        { id: 'purchase1', transactionId: 'tx1' },
+        { id: 'purchase2', transactionId: 'tx2' },
+      ];
+      (IapModule.getPurchaseHistories as jest.Mock).mockResolvedValue(mockHistories);
+
+      const { result, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      // Call the method
+      await act(async () => {
+        await result.current.getPurchaseHistories();
+      });
+
+      // Verify the correct function was called
+      expect(IapModule.getPurchaseHistories).toHaveBeenCalled();
+      expect(result.current.purchaseHistories).toEqual(mockHistories);
+    });
+
+    it('should NOT have purchaseHistory (singular) property', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      // Ensure the singular form is not exposed
+      expect(result.current).not.toHaveProperty('purchaseHistory');
+    });
+
+    it('should NOT have getPurchaseHistory (singular) method', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      // Ensure the singular form method is not exposed
+      expect(result.current).not.toHaveProperty('getPurchaseHistory');
+    });
+  });
+
+  describe('Hook Initialization', () => {
+    it('should initialize connection on mount', async () => {
+      renderHook(() => useIAP());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(IapModule.initConnection).toHaveBeenCalled();
+    });
+
+    it('should set up purchase listeners on successful connection', async () => {
+      const { waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      expect(IapModule.purchaseUpdatedListener).toHaveBeenCalled();
+      expect(IapModule.purchaseErrorListener).toHaveBeenCalled();
+    });
+
+    it('should clean up on unmount', async () => {
+      const { unmount, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      unmount();
+
+      expect(mockRemove).toHaveBeenCalled();
+      expect(IapModule.endConnection).toHaveBeenCalled();
+    });
+  });
+
+  describe('TypeScript Type Definitions', () => {
+    it('should have correct type for purchaseHistories', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useIAP());
+
+      await waitForNextUpdate();
+
+      // This test primarily ensures TypeScript compilation works correctly
+      // with the plural form. The actual runtime test is above.
+      const histories: typeof result.current.purchaseHistories = [];
+      expect(Array.isArray(histories)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added comprehensive test suite for the purchase history naming changes introduced in v2.6.0
- Tests ensure backward compatibility and proper deprecation warnings

## Test Coverage
### purchaseHistory.test.ts
- ✅ Tests that `getPurchaseHistory()` shows deprecation warning
- ✅ Tests that deprecated method still works by calling the new method
- ✅ Tests platform-specific implementations (iOS and Android)
- ✅ Tests parameter handling

### useIap.test.ts
- ✅ Tests that hook exposes `purchaseHistories` (plural) state
- ✅ Tests that hook exposes `getPurchaseHistories()` (plural) method
- ✅ Tests that deprecated singular forms are NOT exposed
- ✅ Tests hook initialization and cleanup

## Related Issues
- Addresses testing needs for #100 (method naming consistency)
- Related to PR #103 (implementation of naming changes)

## Test Plan
```bash
# Run tests
npm test

# Run with coverage
npm test -- --coverage
```

Note: Test dependencies need to be installed first with `npm install`