### PR TITLE
feat(android): update to Google Play Billing Library v8.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,10 +41,18 @@ android {
   lintOptions {
     abortOnError false
   }
+  kotlinOptions {
+    jvmTarget = "17"
+    freeCompilerArgs += ["-Xskip-metadata-version-check"]
+  }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
-    implementation "com.android.billingclient:billing-ktx:7.0.0"
+    implementation "com.android.billingclient:billing-ktx:8.0.0"
     implementation "com.google.android.gms:play-services-base:18.1.0"
 }

--- a/docs/blog/2025-07-22-v2-7-0-release.md
+++ b/docs/blog/2025-07-22-v2-7-0-release.md
@@ -1,0 +1,157 @@
+---
+slug: google-play-billing-v8
+title: Google Play Billing Library v8.0.0 Support
+authors: [hyochan]
+tags: [release, android, google-play-billing]
+---
+
+# Google Play Billing Library v8.0.0 Support
+
+We've updated expo-iap to support Google Play Billing Library v8.0.0, which includes several important changes and improvements for Android in-app purchases.
+
+## Key Changes
+
+### 1. Updated Dependencies
+
+The Android module now uses the latest Google Play Billing Library:
+
+```gradle
+implementation "com.android.billingclient:billing-ktx:8.0.0"
+```
+
+### 2. Removed Deprecated Methods
+
+**getPurchaseHistory is no longer available on Android**
+
+Google Play Billing Library v8 has removed the `queryPurchaseHistoryAsync()` method. The `getPurchaseHistories()` function will now return an empty array on Android with a console warning:
+
+```typescript
+// Before v8
+const history = await getPurchaseHistories(); // Returns purchase history
+
+// After v8 
+const history = await getPurchaseHistories(); // Returns [] on Android with warning
+// Use getAvailablePurchases() instead for active purchases
+```
+
+### 3. Updated API Signatures
+
+The `queryProductDetailsAsync` method now uses `ProductDetailsResult`:
+
+```kotlin
+billingClient.queryProductDetailsAsync(params) { billingResult, productDetailsResult ->
+    val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
+    // Handle products
+}
+```
+
+### 4. New PendingPurchasesParams
+
+The `enablePendingPurchases()` method now requires a `PendingPurchasesParams` parameter:
+
+```kotlin
+.enablePendingPurchases(
+    PendingPurchasesParams.newBuilder()
+        .enableOneTimeProducts()
+        .build()
+)
+```
+
+### 5. Automatic Service Reconnection
+
+The library now includes automatic service reconnection support with `enableAutoServiceReconnection()`, improving reliability when the billing service disconnects unexpectedly:
+
+```kotlin
+.enableAutoServiceReconnection()
+```
+
+### 6. Sub-Response Codes
+
+The library now provides more detailed error information through sub-response codes. For example, when a payment fails due to insufficient funds:
+
+```javascript
+// Error object now includes sub-response codes
+{
+  responseCode: 6, // ERROR
+  debugMessage: "Error processing purchase",
+  subResponseCode: 1, // PAYMENT_DECLINED_DUE_TO_INSUFFICIENT_FUNDS
+  subResponseMessage: "Payment declined due to insufficient funds"
+}
+```
+
+This helps provide better user feedback for specific payment failures.
+
+## Migration Guide
+
+### Breaking Changes Summary
+
+1. **`getPurchaseHistory()` removed** - Use `getAvailablePurchases()` instead
+2. **`querySkuDetailsAsync()` removed** - Already migrated to `queryProductDetailsAsync()`
+3. **`enablePendingPurchases()` signature changed** - Now requires `PendingPurchasesParams`
+4. **`queryPurchasesAsync(skuType)` removed** - Use `queryPurchasesAsync(QueryPurchasesParams)` instead
+
+### For getPurchaseHistory Users
+
+If you're using `getPurchaseHistory()` or `getPurchaseHistories()` on Android:
+
+```typescript
+// Old approach
+const history = await getPurchaseHistories();
+
+// New approach - use getAvailablePurchases for active purchases
+const activePurchases = await getAvailablePurchases();
+```
+
+### No Other Breaking Changes
+
+All other APIs remain compatible. The library handles the v8 changes internally, so most apps won't need any code changes beyond the purchase history migration.
+
+## Benefits
+
+- **Future-Proof**: Compliance with Google Play's latest billing requirements (deadline: August 31, 2025)
+- **Improved Reliability**: Automatic service reconnection reduces connection-related errors
+- **Better API**: More structured response objects with QueryProductDetailsResult
+- **Enhanced Features**: Support for new features and improvements
+
+## Upgrading
+
+To upgrade to version 2.7.0:
+
+```bash
+npm install expo-iap@2.7.0
+# or
+yarn add expo-iap@2.7.0
+# or
+bun add expo-iap@2.7.0
+```
+
+## Requirements
+
+- Android Gradle Plugin 4.0 or higher
+- Kotlin 1.6 or higher
+- JVM target 17 (automatically configured)
+
+## What's New in Google Play Billing Library v8.0.0
+
+### New Features
+- **Multiple purchase options for one-time products** - More flexibility in product offerings
+- **Sub-response codes** - Better error details (e.g., insufficient funds)
+- **Automatic reconnection** - Simplified connection management
+- **Improved queryProductDetailsAsync** - Now returns unfetched products with status codes
+
+### Terminology Changes
+- "In-app items" → "One-time products"
+
+### Removed Methods
+- `queryPurchaseHistory()` - Removed completely
+- `querySkuDetailsAsync()` - Use `queryProductDetailsAsync()`
+- `enablePendingPurchases()` without params - Use with `PendingPurchasesParams`
+- `queryPurchasesAsync(skuType)` - Use `QueryPurchasesParams` version
+
+For complete details, see the [official Android release notes](https://developer.android.com/google/play/billing/release-notes).
+
+## Feedback
+
+If you encounter any issues with this update, please [open an issue](https://github.com/hyochan/expo-iap/issues) on our GitHub repository.
+
+Happy coding! 🚀

--- a/example/app.json
+++ b/example/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "cpk",
-    "slug": "cpk",
+    "name": "expo-iap-example",
+    "slug": "expo-iap-example",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "expo-iap-example",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
@@ -17,7 +17,7 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.crossplatformkorea.cpk"
+      "package": "dev.hyo.martie"
     },
     "plugins": [
       "../app.plugin.js",

--- a/example/app/purchase-flow.tsx
+++ b/example/app/purchase-flow.tsx
@@ -63,11 +63,7 @@ export default function PurchaseFlow() {
   // Load products when component mounts
   useEffect(() => {
     if (connected) {
-      const productIds = [
-        'com.example.premium',
-        'com.example.coins_100',
-        'com.example.remove_ads',
-      ];
+      const productIds = ['dev.hyo.martie.10bulbs', 'dev.hyo.martie.30bulbs'];
       getProducts(productIds);
     }
   }, [connected, getProducts]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,11 +186,12 @@ export const getPurchaseHistories = ({
         );
       },
       android: async () => {
-        const products = await ExpoIapModule.getPurchaseHistoryByType('inapp');
-        const subscriptions = await ExpoIapModule.getPurchaseHistoryByType(
-          'subs',
+        // getPurchaseHistoryByType was removed in Google Play Billing Library v8
+        // Android doesn't provide purchase history anymore, only active purchases
+        console.warn(
+          'getPurchaseHistories is not supported on Android with Google Play Billing Library v8. Use getAvailablePurchases instead to get active purchases.',
         );
-        return products.concat(subscriptions);
+        return [];
       },
     }) || (() => Promise.resolve([]))
   )();


### PR DESCRIPTION
- Update billing-ktx dependency from 7.0.0 to 8.0.0
- Fix Kotlin compatibility by setting JVM target to 17
- Update queryProductDetailsAsync to use QueryProductDetailsResult
- Add PendingPurchasesParams for enablePendingPurchases
- Add deprecation warning for getPurchaseHistories on Android
- Update getPurchaseHistories to return empty array on Android
- Add blog post documenting v8 changes and migration guide

BREAKING CHANGE: getPurchaseHistories no longer returns purchase history on Android. Use getAvailablePurchases instead for active purchases.