### PR TITLE
fix: add iOS 18.4+ availability check for appTransactionID

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -269,7 +269,6 @@ public class ExpoIapModule: Module {
                 }
                 
                 var result: [String: Any?] = [
-                    "appTransactionID": appTransaction.appTransactionID,
                     "bundleID": appTransaction.bundleID,
                     "appVersion": appTransaction.appVersion,
                     "originalAppVersion": appTransaction.originalAppVersion,
@@ -284,6 +283,7 @@ public class ExpoIapModule: Module {
                 ]
                 
                 if #available(iOS 18.4, *) {
+                    result["appTransactionID"] = appTransaction.appTransactionID
                     result["originalPlatform"] = appTransaction.originalPlatform.rawValue
                 }
                 

--- a/src/types/ExpoIapIos.types.ts
+++ b/src/types/ExpoIapIos.types.ts
@@ -142,7 +142,8 @@ export type ProductPurchaseIos = PurchaseBase & {
 };
 
 export type AppTransactionIOS = {
-  appTransactionID: string;
+  appTransactionID?: string; // Only available in iOS 18.4+
+  originalPlatform?: string; // Only available in iOS 18.4+
   bundleID: string;
   appVersion: string;
   originalAppVersion: string;
@@ -153,6 +154,5 @@ export type AppTransactionIOS = {
   signedDate: number;
   appID?: number;
   appVersionID?: number;
-  originalPlatform?: string; // Only available in iOS 18.4+
   preorderDate?: number;
 };


### PR DESCRIPTION
## Summary
- Fix iOS compatibility issue by adding proper availability check for `appTransactionID`
- Move `appTransactionID` inside iOS 18.4+ availability check in Swift code  
- Update TypeScript type to make `appTransactionID` optional for iOS versions below 18.4

## Problem
The `appTransactionID` property was being accessed without version checking, which could cause crashes on iOS devices running versions below 18.4.

## Solution
- Wrapped `appTransactionID` access in `if #available(iOS 18.4, *)` check
- Updated TypeScript interface to reflect that this property is optional

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Build completes successfully
- [x] Test on iOS devices with version >= 18.4
- [ ] Test on iOS devices with version < 18.4
