### PR TITLE
fix: resolve iOS build error in promoted product event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.7.5] - 2025-07-24
+
+### Added
+- iOS promoted product support for App Store promoted purchases
+- `promotedProductListenerIOS()` listener for handling promoted product events  
+- `getPromotedProductIOS()` method to get promoted product details
+- `buyPromotedProductIOS()` method to complete promoted product purchases
+- `promotedProductIOS` state in useIAP hook for promoted product data
+- `onPromotedProductIOS` callback option in useIAP hook
+
+### Changed
+- Promoted product listener now passes full Product object instead of just productId string
+- Updated all promoted product documentation and examples
+- Removed Manual Connection Management section from lifecycle documentation
+
+### Fixed
+- iOS build error in promoted product event handler
+- Type safety improvements for promoted product functionality
+
 ## [2.7.4] - 2025-07-24
 
 ### Fixed

--- a/docs/docs/api/methods/listeners.md
+++ b/docs/docs/api/methods/listeners.md
@@ -130,9 +130,9 @@ Listens for promoted product purchases initiated from the App Store. This fires 
 import {promotedProductListenerIOS, getPromotedProductIOS, buyPromotedProductIOS} from 'expo-iap';
 
 const setupPromotedProductListener = () => {
-  const subscription = promotedProductListenerIOS((productId) => {
-    console.log('Promoted product purchase initiated:', productId);
-    handlePromotedProduct(productId);
+  const subscription = promotedProductListenerIOS((product) => {
+    console.log('Promoted product purchase initiated:', product);
+    handlePromotedProduct(product);
   });
 
   return () => {
@@ -142,26 +142,14 @@ const setupPromotedProductListener = () => {
   };
 };
 
-const handlePromotedProduct = async (productId) => {
+const handlePromotedProduct = async (product) => {
   try {
-    // Fetch the product details
-    const products = await requestProducts({ skus: [productId], type: 'inapp' });
-    const product = products[0];
+    // Show your custom purchase UI with the product details
+    const confirmed = await showProductConfirmation(product);
 
-    if (product) {
-      // Show product details to user and confirm purchase
-      const confirmed = await showProductConfirmation(product);
-    // Get the promoted product details
-    const promotedProduct = await getPromotedProductIOS();
-
-    if (promotedProduct) {
-      // Show your custom purchase UI
-      const confirmed = await showProductConfirmation(promotedProduct);
-
-      if (confirmed) {
-        // Complete the promoted purchase
-        await buyPromotedProductIOS();
-      }
+    if (confirmed) {
+      // Complete the promoted purchase
+      await buyPromotedProductIOS();
     }
   } catch (error) {
     console.error('Error handling promoted product:', error);
@@ -172,7 +160,7 @@ const handlePromotedProduct = async (productId) => {
 **Parameters:**
 
 - `callback` (function): Function to call when a promoted product is selected
-  - `productId` (string): The ID of the promoted product
+  - `product` (Product): The promoted product object
 
 **Returns:** Subscription object with `remove()` method
 

--- a/docs/docs/api/methods/listeners.md
+++ b/docs/docs/api/methods/listeners.md
@@ -14,7 +14,7 @@ expo-iap provides event listeners to handle purchase updates and errors. These l
 
 ## purchaseUpdatedListener()
 
-Listens for purchase updates from the store.
+Listens for purchase updates from **the** store.
 
 ```tsx
 import {purchaseUpdatedListener} from 'expo-iap';
@@ -122,15 +122,15 @@ const handlePurchaseError = (error) => {
 
 **Returns:** Subscription object with `remove()` method
 
-## promotedProductListener() (iOS only)
+## promotedProductListenerIOS() (iOS only)
 
-Listens for promoted product purchases initiated from the App Store.
+Listens for promoted product purchases initiated from the App Store. This fires when a user taps on a promoted product in the App Store.
 
 ```tsx
-import {promotedProductListener} from 'expo-iap';
+import {promotedProductListenerIOS, getPromotedProductIOS, buyPromotedProductIOS} from 'expo-iap';
 
 const setupPromotedProductListener = () => {
-  const subscription = promotedProductListener((productId) => {
+  const subscription = promotedProductListenerIOS((productId) => {
     console.log('Promoted product purchase initiated:', productId);
     handlePromotedProduct(productId);
   });
@@ -151,9 +151,16 @@ const handlePromotedProduct = async (productId) => {
     if (product) {
       // Show product details to user and confirm purchase
       const confirmed = await showProductConfirmation(product);
+    // Get the promoted product details
+    const promotedProduct = await getPromotedProductIOS();
+
+    if (promotedProduct) {
+      // Show your custom purchase UI
+      const confirmed = await showProductConfirmation(promotedProduct);
 
       if (confirmed) {
-        await requestPurchase({sku: productId});
+        // Complete the promoted purchase
+        await buyPromotedProductIOS();
       }
     }
   } catch (error) {
@@ -168,6 +175,13 @@ const handlePromotedProduct = async (productId) => {
   - `productId` (string): The ID of the promoted product
 
 **Returns:** Subscription object with `remove()` method
+
+**Related Methods:**
+
+- `getPromotedProductIOS()`: Get the promoted product details
+- `buyPromotedProductIOS()`: Complete the promoted product purchase
+
+**Note:** This listener only works on iOS devices and is used for handling App Store promoted products.
 
 ## Using Listeners with React Hooks
 

--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -191,18 +191,18 @@ interface UseIAPOptions {
   ));
   ```
 
-#### promotedProductIdIOS
+#### promotedProductIOS
 
-- **Type**: `string | undefined`
-- **Description**: The product ID of the promoted product (iOS only)
+- **Type**: `Product | undefined`
+- **Description**: The promoted product details (iOS only)
 - **Example**:
   ```tsx
   useEffect(() => {
-    if (promotedProductIdIOS) {
+    if (promotedProductIOS) {
       // Handle promoted product
-      handlePromotedProduct(promotedProductIdIOS);
+      handlePromotedProduct(promotedProductIOS);
     }
-  }, [promotedProductIdIOS]);
+  }, [promotedProductIOS]);
   ```
 
 ### Methods
@@ -584,31 +584,24 @@ Handle App Store promoted products when users tap on them in the App Store:
 ```tsx
 const PromotedProductExample = () => {
   const {
-    promotedProductIdIOS,
-    getPromotedProductIOS,
+    promotedProductIOS,
     buyPromotedProductIOS,
-    getProducts,
   } = useIAP({
-    onPromotedProductIOS: (productId) => {
-      console.log('Promoted product detected:', productId);
+    onPromotedProductIOS: (product) => {
+      console.log('Promoted product detected:', product);
     },
   });
 
   useEffect(() => {
-    if (promotedProductIdIOS) {
+    if (promotedProductIOS) {
       handlePromotedProduct();
     }
-  }, [promotedProductIdIOS]);
+  }, [promotedProductIOS]);
 
   const handlePromotedProduct = async () => {
     try {
-      // Get promoted product details
-      const promotedProduct = await getPromotedProductIOS();
-      
-      if (!promotedProduct) return;
-
       // Show your custom purchase UI
-      const confirmed = await showPurchaseConfirmation(promotedProduct);
+      const confirmed = await showPurchaseConfirmation(promotedProductIOS);
       
       if (confirmed) {
         // Complete the promoted purchase

--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -191,6 +191,20 @@ interface UseIAPOptions {
   ));
   ```
 
+#### promotedProductIdIOS
+
+- **Type**: `string | undefined`
+- **Description**: The product ID of the promoted product (iOS only)
+- **Example**:
+  ```tsx
+  useEffect(() => {
+    if (promotedProductIdIOS) {
+      // Handle promoted product
+      handlePromotedProduct(promotedProductIdIOS);
+    }
+  }, [promotedProductIdIOS]);
+  ```
+
 ### Methods
 
 #### requestProducts
@@ -367,6 +381,37 @@ interface UseIAPOptions {
   };
   ```
 
+#### getPromotedProductIOS
+
+- **Type**: `() => Promise<any | null>` 
+- **Description**: Get the promoted product details (iOS only)
+- **Example**:
+  ```tsx
+  const handlePromotedProduct = async () => {
+    const promotedProduct = await getPromotedProductIOS();
+    if (promotedProduct) {
+      console.log('Promoted product:', promotedProduct);
+      // Show custom purchase UI
+    }
+  };
+  ```
+
+#### buyPromotedProductIOS
+
+- **Type**: `() => Promise<void>`
+- **Description**: Complete the purchase of a promoted product (iOS only)
+- **Example**:
+  ```tsx
+  const completePurchase = async () => {
+    try {
+      await buyPromotedProductIOS();
+      console.log('Promoted product purchase completed');
+    } catch (error) {
+      console.error('Failed to purchase promoted product:', error);
+    }
+  };
+  ```
+
 ## Platform-Specific Usage
 
 ### iOS Example
@@ -531,6 +576,69 @@ const {requestPurchase} = useIAP({
      }
    }, [connected, productsLoaded]);
    ```
+
+## Promoted Products (iOS Only)
+
+Handle App Store promoted products when users tap on them in the App Store:
+
+```tsx
+const PromotedProductExample = () => {
+  const {
+    promotedProductIdIOS,
+    getPromotedProductIOS,
+    buyPromotedProductIOS,
+    getProducts,
+  } = useIAP({
+    onPromotedProductIOS: (productId) => {
+      console.log('Promoted product detected:', productId);
+    },
+  });
+
+  useEffect(() => {
+    if (promotedProductIdIOS) {
+      handlePromotedProduct();
+    }
+  }, [promotedProductIdIOS]);
+
+  const handlePromotedProduct = async () => {
+    try {
+      // Get promoted product details
+      const promotedProduct = await getPromotedProductIOS();
+      
+      if (!promotedProduct) return;
+
+      // Show your custom purchase UI
+      const confirmed = await showPurchaseConfirmation(promotedProduct);
+      
+      if (confirmed) {
+        // Complete the promoted purchase
+        await buyPromotedProductIOS();
+      }
+    } catch (error) {
+      console.error('Error handling promoted product:', error);
+    }
+  };
+
+  const showPurchaseConfirmation = async (product: any) => {
+    return new Promise((resolve) => {
+      Alert.alert(
+        'Purchase Product',
+        `Would you like to purchase ${product.localizedTitle} for ${product.price}?`,
+        [
+          { text: 'Cancel', onPress: () => resolve(false), style: 'cancel' },
+          { text: 'Buy', onPress: () => resolve(true) },
+        ],
+      );
+    });
+  };
+
+  return (
+    <View>
+      {/* Your regular store UI */}
+    </View>
+  );
+};
+```
 
 ## See Also
 

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -82,49 +82,6 @@ if (!connected) {
 return <StoreView />;
 ```
 
-## Manual Connection Management
-
-If you need more control over the connection lifecycle, you can use the low-level methods:
-
-```tsx
-import {initConnection, endConnection} from 'expo-iap';
-
-class StoreManager {
-  async initialize() {
-    try {
-      await initConnection();
-      console.log('Store connection initialized');
-
-      // Set up purchase listeners
-      this.setupPurchaseListeners();
-    } catch (error) {
-      console.error('Failed to initialize store connection:', error);
-    }
-  }
-
-  async cleanup() {
-    try {
-      // Remove listeners
-      this.removePurchaseListeners();
-
-      // End connection
-      await endConnection();
-      console.log('Store connection ended');
-    } catch (error) {
-      console.error('Failed to end store connection:', error);
-    }
-  }
-
-  setupPurchaseListeners() {
-    // Set up purchase update and error listeners
-  }
-
-  removePurchaseListeners() {
-    // Remove listeners to prevent memory leaks
-  }
-}
-```
-
 ## Component Lifecycle Integration
 
 ### Class Components

--- a/docs/versioned_docs/version-2.6/guides/lifecycle.md
+++ b/docs/versioned_docs/version-2.6/guides/lifecycle.md
@@ -82,49 +82,6 @@ if (!connected) {
 return <StoreView />;
 ```
 
-## Manual Connection Management
-
-If you need more control over the connection lifecycle, you can use the low-level methods:
-
-```tsx
-import {initConnection, endConnection} from 'expo-iap';
-
-class StoreManager {
-  async initialize() {
-    try {
-      await initConnection();
-      console.log('Store connection initialized');
-
-      // Set up purchase listeners
-      this.setupPurchaseListeners();
-    } catch (error) {
-      console.error('Failed to initialize store connection:', error);
-    }
-  }
-
-  async cleanup() {
-    try {
-      // Remove listeners
-      this.removePurchaseListeners();
-
-      // End connection
-      await endConnection();
-      console.log('Store connection ended');
-    } catch (error) {
-      console.error('Failed to end store connection:', error);
-    }
-  }
-
-  setupPurchaseListeners() {
-    // Set up purchase update and error listeners
-  }
-
-  removePurchaseListeners() {
-    // Remove listeners to prevent memory leaks
-  }
-}
-```
-
 ## Component Lifecycle Integration
 
 ### Class Components

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -18,6 +18,7 @@ func logDebug(_ message: String) {
 struct IapEvent {
     static let PurchaseUpdated = "purchase-updated"
     static let PurchaseError = "purchase-error"
+    static let PromotedProductIOS = "promoted-product-ios"
 }
 
 @available(iOS 15.0, *)
@@ -225,6 +226,9 @@ public class ExpoIapModule: Module {
     private var updateListenerTask: Task<Void, Error>?
     private var subscriptionPollingTask: Task<Void, Error>?
     private var pollingSkus: Set<String> = []
+    private var paymentObserver: PaymentObserver?
+    private var promotedPayment: SKPayment?
+    private var promotedProduct: SKProduct?
 
     public func definition() -> ModuleDefinition {
         Name("ExpoIap")
@@ -247,6 +251,13 @@ public class ExpoIapModule: Module {
 
         Function("initConnection") { () -> Bool in
             self.productStore = ProductStore()
+            
+            // Set up PaymentObserver for promoted products
+            if self.paymentObserver == nil {
+                self.paymentObserver = PaymentObserver(module: self)
+                SKPaymentQueue.default().add(self.paymentObserver!)
+            }
+            
             return AppStore.canMakePayments
         }
 
@@ -303,6 +314,42 @@ public class ExpoIapModule: Module {
                 )
             }
         }
+        
+        AsyncFunction("getPromotedProduct") { () -> [String: Any?]? in
+            guard let product = self.promotedProduct else {
+                return nil
+            }
+            
+            // Convert SKProduct to dictionary
+            return [
+                "productIdentifier": product.productIdentifier,
+                "localizedTitle": product.localizedTitle,
+                "localizedDescription": product.localizedDescription,
+                "price": product.price.doubleValue,
+                "priceLocale": [
+                    "currencyCode": product.priceLocale.currencyCode ?? "",
+                    "currencySymbol": product.priceLocale.currencySymbol ?? "",
+                    "countryCode": product.priceLocale.regionCode ?? ""
+                ]
+            ]
+        }
+        
+        AsyncFunction("buyPromotedProduct") { () -> Void in
+            guard let payment = self.promotedPayment else {
+                throw Exception(
+                    name: "ExpoIapModule",
+                    description: "No promoted product available",
+                    code: IapErrorCode.itemUnavailable
+                )
+            }
+            
+            // Add the deferred payment to the queue
+            SKPaymentQueue.default().add(payment)
+            
+            // Clear the promoted product data
+            self.promotedPayment = nil
+            self.promotedProduct = nil
+        }
 
         AsyncFunction("getItems") { (skus: [String]) -> [[String: Any?]?] in
             guard let productStore = self.productStore else {
@@ -335,6 +382,13 @@ public class ExpoIapModule: Module {
             self.transactions.removeAll()
             self.productStore = nil
             self.removeTransactionObserver()
+            
+            // Remove PaymentObserver
+            if let observer = self.paymentObserver {
+                SKPaymentQueue.default().remove(observer)
+                self.paymentObserver = nil
+            }
+            
             return true
         }
 
@@ -920,5 +974,37 @@ public class ExpoIapModule: Module {
         } else {
             throw Exception(name: "ExpoIapModule", description: "App Store receipt not found", code: IapErrorCode.receiptFailed)
         }
+    }
+    
+    // Called by PaymentObserver when a promoted product is received
+    func handlePromotedProduct(payment: SKPayment, product: SKProduct) {
+        self.promotedPayment = payment
+        self.promotedProduct = product
+        
+        if hasListeners {
+            sendEvent(IapEvent.PromotedProductIOS, ["productId": product.productIdentifier])
+        }
+    }
+}
+
+// PaymentObserver for handling promoted products
+@available(iOS 15.0, *)
+class PaymentObserver: NSObject, SKPaymentTransactionObserver {
+    weak var module: ExpoIapModule?
+    
+    init(module: ExpoIapModule) {
+        self.module = module
+    }
+    
+    // Required by SKPaymentTransactionObserver protocol but not used
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        // We don't handle transactions here as StoreKit 2 handles them in ExpoIapModule
+    }
+    
+    // Handle promoted products from App Store
+    func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {
+        module?.handlePromotedProduct(payment: payment, product: product)
+        // Return false to defer the payment
+        return false
     }
 }

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -982,7 +982,18 @@ public class ExpoIapModule: Module {
         self.promotedProduct = product
         
         if hasListeners {
-            sendEvent(IapEvent.PromotedProductIOS, ["productId": product.productIdentifier])
+            let productData: [String: Any] = [
+                "productIdentifier": product.productIdentifier,
+                "localizedTitle": product.localizedTitle,
+                "localizedDescription": product.localizedDescription,
+                "price": product.price.doubleValue,
+                "priceLocale": [
+                    "currencyCode": product.priceLocale.currencyCode ?? "",
+                    "currencySymbol": product.priceLocale.currencySymbol ?? "",
+                    "countryCode": product.priceLocale.regionCode ?? ""
+                ]
+            ]
+            sendEvent(IapEvent.PromotedProductIOS, productData)
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.7.5-rc.1",
+  "version": "2.7.5",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.7.4",
+  "version": "2.7.5-rc.1",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export enum IapEvent {
   PurchaseError = 'purchase-error',
   /** @deprecated Use PurchaseUpdated instead. This will be removed in a future version. */
   TransactionIapUpdated = 'iap-transaction-updated',
+  PromotedProductIOS = 'promoted-product-ios',
 }
 
 export function setValueAsync(value: string) {
@@ -74,6 +75,36 @@ export const purchaseErrorListener = (
   listener: (error: PurchaseError) => void,
 ) => {
   return emitter.addListener(IapEvent.PurchaseError, listener);
+};
+
+/**
+ * iOS-only listener for App Store promoted product events.
+ * This fires when a user taps on a promoted product in the App Store.
+ * 
+ * @param listener - Callback function that receives the promoted product ID
+ * @returns EventSubscription that can be used to unsubscribe
+ * 
+ * @example
+ * ```typescript
+ * const subscription = promotedProductListenerIOS((productId) => {
+ *   console.log('Promoted product:', productId);
+ *   // Handle the promoted product
+ * });
+ * 
+ * // Later, clean up
+ * subscription.remove();
+ * ```
+ * 
+ * @platform iOS
+ */
+export const promotedProductListenerIOS = (
+  listener: (productId: string) => void,
+) => {
+  if (Platform.OS !== 'ios') {
+    console.warn('promotedProductListenerIOS: This listener is only available on iOS');
+    return { remove: () => {} };
+  }
+  return emitter.addListener(IapEvent.PromotedProductIOS, listener);
 };
 
 export function initConnection() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,13 +81,13 @@ export const purchaseErrorListener = (
  * iOS-only listener for App Store promoted product events.
  * This fires when a user taps on a promoted product in the App Store.
  * 
- * @param listener - Callback function that receives the promoted product ID
+ * @param listener - Callback function that receives the promoted product details
  * @returns EventSubscription that can be used to unsubscribe
  * 
  * @example
  * ```typescript
- * const subscription = promotedProductListenerIOS((productId) => {
- *   console.log('Promoted product:', productId);
+ * const subscription = promotedProductListenerIOS((product) => {
+ *   console.log('Promoted product:', product);
  *   // Handle the promoted product
  * });
  * 
@@ -98,7 +98,7 @@ export const purchaseErrorListener = (
  * @platform iOS
  */
 export const promotedProductListenerIOS = (
-  listener: (productId: string) => void,
+  listener: (product: Product) => void,
 ) => {
   if (Platform.OS !== 'ios') {
     console.warn('promotedProductListenerIOS: This listener is only available on iOS');

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -278,6 +278,32 @@ export const getAppTransactionIOS = (): Promise<AppTransactionIOS | null> => {
   return ExpoIapModule.getAppTransaction();
 };
 
+/**
+ * Get the promoted product details (iOS only).
+ * This is called after a promoted product event is received from the App Store.
+ * 
+ * @returns Promise resolving to the promoted product details or null if none available
+ * @throws Error if called on non-iOS platform
+ * 
+ * @platform iOS
+ */
+export const getPromotedProductIOS = (): Promise<any | null> => {
+  return ExpoIapModule.getPromotedProduct();
+};
+
+/**
+ * Complete the purchase of a promoted product (iOS only).
+ * This should be called after showing your purchase UI for a promoted product.
+ * 
+ * @returns Promise resolving when the purchase is initiated
+ * @throws Error if called on non-iOS platform or no promoted product is available
+ * 
+ * @platform iOS
+ */
+export const buyPromotedProductIOS = (): Promise<void> => {
+  return ExpoIapModule.buyPromotedProduct();
+};
+
 // ============= DEPRECATED FUNCTIONS =============
 // These will be removed in version 3.0.0
 

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -42,6 +42,7 @@ type UseIap = {
   availablePurchases: ProductPurchase[];
   currentPurchase?: ProductPurchase;
   currentPurchaseError?: PurchaseError;
+  promotedProductIOS?: Product;
   clearCurrentPurchase: () => void;
   clearCurrentPurchaseError: () => void;
   finishTransaction: ({
@@ -85,14 +86,14 @@ export interface UseIAPOptions {
   ) => void;
   onPurchaseError?: (error: PurchaseError) => void;
   onSyncError?: (error: Error) => void;
-  onPromotedProductIOS?: (productId: string) => void;
   shouldAutoSyncPurchases?: boolean; // New option to control auto-syncing
+  onPromotedProductIOS?: (product: Product) => void;
 }
 
 export function useIAP(options?: UseIAPOptions): UseIap {
   const [connected, setConnected] = useState<boolean>(false);
   const [products, setProducts] = useState<Product[]>([]);
-  const [promotedProductsIOS, setPromotedProductsIOS] = useState<
+  const [promotedProductsIOS] = useState<
     ProductPurchase[]
   >([]);
   const [subscriptions, setSubscriptions] = useState<SubscriptionProduct[]>([]);
@@ -103,9 +104,10 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     ProductPurchase[]
   >([]);
   const [currentPurchase, setCurrentPurchase] = useState<ProductPurchase>();
+  const [promotedProductIOS, setPromotedProductIOS] = useState<Product>();
   const [currentPurchaseError, setCurrentPurchaseError] =
     useState<PurchaseError>();
-  const [promotedProductIdIOS, setPromotedProductIdIOS] = useState<string>();
+  const [promotedProductIdIOS] = useState<string>();
 
   const optionsRef = useRef<UseIAPOptions | undefined>(options);
 
@@ -381,34 +383,15 @@ export function useIAP(options?: UseIAPOptions): UseIap {
       );
 
       if (Platform.OS === 'ios') {
-        // iOS promoted products are handled through regular purchase updates
-        subscriptionsRef.current.promotedProductsIos = purchaseUpdatedListener(
-          async (purchase: Purchase | SubscriptionPurchase) => {
-            // Add to promoted products if it's a promoted transaction (avoid duplicates)
-            setPromotedProductsIOS((prevProducts) =>
-              mergeWithDuplicateCheck(
-                prevProducts,
-                [purchase as ProductPurchase],
-                (product) => product.transactionId || product.id,
-              ),
-            );
-
-            // Refresh subscription status if it's a subscription purchase
-            if ('expirationDateIos' in purchase) {
-              await refreshSubscriptionStatus(purchase.id);
-            }
-          },
-        );
-        
-        // Listen for promoted product events
-        subscriptionsRef.current.promotedProductIOS = promotedProductListenerIOS(
-          (productId: string) => {
-            setPromotedProductIdIOS(productId);
+        // iOS promoted products listener
+        subscriptionsRef.current.promotedProductsIos =
+          promotedProductListenerIOS((product: Product) => {
+            setPromotedProductIOS(product);
+            
             if (optionsRef.current?.onPromotedProductIOS) {
-              optionsRef.current.onPromotedProductIOS(productId);
+              optionsRef.current.onPromotedProductIOS(product);
             }
-          },
-        );
+          });
       }
     }
   }, [refreshSubscriptionStatus, mergeWithDuplicateCheck]);
@@ -438,6 +421,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     availablePurchases,
     currentPurchase,
     currentPurchaseError,
+    promotedProductIOS,
     clearCurrentPurchase,
     clearCurrentPurchaseError,
     getAvailablePurchases: getAvailablePurchasesInternal,

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -9,13 +9,14 @@ import {
   initConnection,
   purchaseErrorListener,
   purchaseUpdatedListener,
+  promotedProductListenerIOS,
   getAvailablePurchases,
   getPurchaseHistories,
   finishTransaction as finishTransactionInternal,
   requestPurchase as requestPurchaseInternal,
   requestProducts,
 } from './';
-import {syncIOS, validateReceiptIOS} from './modules/ios';
+import {syncIOS, validateReceiptIOS, getPromotedProductIOS, buyPromotedProductIOS} from './modules/ios';
 import {validateReceiptAndroid} from './modules/android';
 
 // Types
@@ -35,6 +36,7 @@ type UseIap = {
   connected: boolean;
   products: Product[];
   promotedProductsIOS: ProductPurchase[];
+  promotedProductIdIOS?: string;
   subscriptions: SubscriptionProduct[];
   purchaseHistories: ProductPurchase[];
   availablePurchases: ProductPurchase[];
@@ -73,6 +75,8 @@ type UseIap = {
     },
   ) => Promise<any>;
   restorePurchases: () => Promise<void>; // 구매 복원 함수 추가
+  getPromotedProductIOS: () => Promise<any | null>;
+  buyPromotedProductIOS: () => Promise<void>;
 };
 
 export interface UseIAPOptions {
@@ -81,6 +85,7 @@ export interface UseIAPOptions {
   ) => void;
   onPurchaseError?: (error: PurchaseError) => void;
   onSyncError?: (error: Error) => void;
+  onPromotedProductIOS?: (productId: string) => void;
   shouldAutoSyncPurchases?: boolean; // New option to control auto-syncing
 }
 
@@ -100,6 +105,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   const [currentPurchase, setCurrentPurchase] = useState<ProductPurchase>();
   const [currentPurchaseError, setCurrentPurchaseError] =
     useState<PurchaseError>();
+  const [promotedProductIdIOS, setPromotedProductIdIOS] = useState<string>();
 
   const optionsRef = useRef<UseIAPOptions | undefined>(options);
 
@@ -132,6 +138,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     purchaseUpdate?: EventSubscription;
     purchaseError?: EventSubscription;
     promotedProductsIos?: EventSubscription;
+    promotedProductIOS?: EventSubscription;
   }>({});
 
   const subscriptionsRefState = useRef<SubscriptionProduct[]>([]);
@@ -151,7 +158,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   const getProductsInternal = useCallback(
     async (skus: string[]): Promise<void> => {
       try {
-        const result = await requestProducts({ skus, type: 'inapp' });
+        const result = await requestProducts({skus, type: 'inapp'});
         setProducts((prevProducts) =>
           mergeWithDuplicateCheck(
             prevProducts,
@@ -169,7 +176,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   const getSubscriptionsInternal = useCallback(
     async (skus: string[]): Promise<void> => {
       try {
-        const result = await requestProducts({ skus, type: 'subs' });
+        const result = await requestProducts({skus, type: 'subs'});
         setSubscriptions((prevSubscriptions) =>
           mergeWithDuplicateCheck(
             prevSubscriptions,
@@ -392,6 +399,16 @@ export function useIAP(options?: UseIAPOptions): UseIap {
             }
           },
         );
+        
+        // Listen for promoted product events
+        subscriptionsRef.current.promotedProductIOS = promotedProductListenerIOS(
+          (productId: string) => {
+            setPromotedProductIdIOS(productId);
+            if (optionsRef.current?.onPromotedProductIOS) {
+              optionsRef.current.onPromotedProductIOS(productId);
+            }
+          },
+        );
       }
     }
   }, [refreshSubscriptionStatus, mergeWithDuplicateCheck]);
@@ -404,6 +421,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
       currentSubscriptions.purchaseUpdate?.remove();
       currentSubscriptions.purchaseError?.remove();
       currentSubscriptions.promotedProductsIos?.remove();
+      currentSubscriptions.promotedProductIOS?.remove();
       endConnection();
       setConnected(false);
     };
@@ -413,6 +431,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     connected,
     products,
     promotedProductsIOS,
+    promotedProductIdIOS,
     subscriptions,
     purchaseHistories,
     finishTransaction,
@@ -429,5 +448,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     restorePurchases,
     getProducts: getProductsInternal,
     getSubscriptions: getSubscriptionsInternal,
+    getPromotedProductIOS,
+    buyPromotedProductIOS,
   };
 }


### PR DESCRIPTION
## Summary
- Fixed iOS build error where sendEvent was receiving incorrect argument type
- Changed from passing plain string to dictionary format with 'productId' key

## Test plan
- [x] Build the iOS project successfully
- [ ] Test promoted product functionality:
  1. Configure a promoted in-app purchase in App Store Connect
  2. Install the app via TestFlight or development build
  3. Access the app from App Store product page with promoted IAP
  4. Verify the promoted product event is triggered with format: `{productId: 'com.example.product'}`
  5. Check console logs or event listeners receive the correct data structure

## Related Issues

closes #117 #118