### PR TITLE
fix: iOS hot reload issues with concurrent StoreKit operations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - iOS: Fixed hot reload issues with concurrent StoreKit operations
 - iOS: Resolved race conditions in `Promise.all` usage
 - iOS: Improved state cleanup on `initConnection()`
+- Fixed `useIAP` hook's internal methods to use `requestProducts` instead of deprecated `getSubscriptions`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,71 +1,105 @@
 # Changelog
 
+## [2.7.7] - TBD
+
+### Fixed
+
+- iOS: Fixed hot reload issues with concurrent StoreKit operations
+- iOS: Resolved race conditions in `Promise.all` usage
+- iOS: Improved state cleanup on `initConnection()`
+
+### Changed
+
+- iOS: Added `ensureConnection()` pattern matching Android
+- iOS: Simplified module architecture
+
+## [2.7.6] - 2025-08-01
+
+### Fixed
+
+- Fixed `initConnection()` return type
+
+### Documentation
+
+- Added available-purchases example
+- Improved build error FAQs
+- Enhanced setup documentation
+
 ## [2.7.5] - 2025-07-24
 
 ### Added
-- iOS promoted product support for App Store promoted purchases
-- `promotedProductListenerIOS()` listener for handling promoted product events  
-- `getPromotedProductIOS()` method to get promoted product details
-- `buyPromotedProductIOS()` method to complete promoted product purchases
-- `promotedProductIOS` state in useIAP hook for promoted product data
-- `onPromotedProductIOS` callback option in useIAP hook
+
+- iOS promoted product support
+- `promotedProductListenerIOS()`, `getPromotedProductIOS()`, `buyPromotedProductIOS()` methods
+- Promoted product support in useIAP hook
 
 ### Changed
-- Promoted product listener now passes full Product object instead of just productId string
-- Updated all promoted product documentation and examples
-- Removed Manual Connection Management section from lifecycle documentation
+
+- Promoted product listener now returns full Product object
+- Updated documentation and examples
 
 ### Fixed
-- iOS build error in promoted product event handler
-- Type safety improvements for promoted product functionality
+
+- iOS build error in promoted product handler
+- Type safety improvements
 
 ## [2.7.4] - 2025-07-24
 
 ### Fixed
-- Add iOS 18.4+ availability check for `appTransactionID` property
-- Update TypeScript type to make `appTransactionID` optional for iOS versions below 18.4
-- Ensure compatibility with devices running iOS versions below 18.4
+
+- iOS 18.4+ availability check for `appTransactionID`
+- TypeScript compatibility for older iOS versions
 
 ## [2.7.3] - 2025-07-23
 
 ### Fixed
-- Upgraded Android Google Play Billing Library to v8.0.0
-- Fixed Kotlin version compatibility issues with expo-modules-core
+
+- Android Google Play Billing Library v8.0.0 upgrade
+- Kotlin version compatibility
 
 ### Changed
-- Android now requires Kotlin 2.0+ for Google Play Billing Library v8.0.0 support
-- Added requirement for `expo-build-properties` configuration to override Kotlin version
+
+- Android requires Kotlin 2.0+
+- Added expo-build-properties requirement
 
 ### Documentation
-- Added Android configuration section in README explaining the need for expo-build-properties
-- Documented Kotlin version requirement for Android builds
+
+- Android configuration guide
+- Kotlin version requirements
 
 ## [2.7.2] - 2025-07-22
 
 ### Added
-- iOS 16.0+ app transaction support with SDK version check (#113)
+
+- iOS 16.0+ app transaction support
 
 ## [2.7.1] - 2025-07-22
 
 ### Fixed
-- Add missing `requestProducts()` API that was discussed in PR #109 but not included in the merge
-- Add deprecation warnings to `getProducts()` and `getSubscriptions()` 
-- Fix `getStorefrontIOS()` to show warning instead of throwing error on non-iOS platforms
-- Add `requestProducts` to useIap hook for consistency with other APIs
-- Fix documentation CI build failures (broken anchors, missing tags, truncation marker)
+
+- Added missing `requestProducts()` API
+- Fixed `getStorefrontIOS()` platform handling
+- Documentation build fixes
+
+### Changed
+
+- Added deprecation warnings to `getProducts()` and `getSubscriptions()`
 
 ## [2.7.0] - 2025-07-22
 
 ### Added
-- New platform-specific API structure for `requestPurchase` with explicit `ios` and `android` parameters
-- Support for Google Play Billing Library v8.0.0
-- Automatic service reconnection on Android for improved reliability
-- Detailed sub-response error codes for better error handling
+
+- Platform-specific API for `requestPurchase`
+- Google Play Billing Library v8.0.0 support
+- Android automatic reconnection
+- Detailed error codes
 
 ### Changed
-- Deprecated `requestSubscription` in favor of `requestPurchase` with `type: 'subs'`
-- `getPurchaseHistory` is no longer available on Android (removed in Google Play Billing v8)
+
+- Deprecated `requestSubscription`
+- Removed Android `getPurchaseHistory()`
 
 ### Breaking Changes
-- Android: `getPurchaseHistory()` removed - use `getAvailablePurchases()` instead
-- Android: Requires Google Play Billing Library v8.0.0
+
+- Android: `getPurchaseHistory()` removed
+- Android: Requires Google Play Billing v8.0.0

--- a/docs/docs/guides/ios-hot-reload-fix.md
+++ b/docs/docs/guides/ios-hot-reload-fix.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 10
+title: iOS Hot Reload Fix
+---
+
+## Overview
+
+Version 2.7.7 fixes iOS hot reload issues with concurrent StoreKit operations.
+
+## The Problem
+
+During hot reload, concurrent IAP operations would fail:
+
+```typescript
+// Would fail on iOS during hot reload
+await Promise.all([
+  requestProducts({skus: productIds}),
+  getAvailablePurchases(), // Returns empty or fails
+]);
+```
+
+## The Solution
+
+The iOS native module now:
+
+- Cleans up state on `initConnection()`
+- Validates connections with `ensureConnection()` (like Android)
+- Properly manages StoreKit resources
+
+## What Changed
+
+- All iOS IAP methods now handle hot reload correctly
+- No code changes needed - works automatically
+- Affects: `requestProducts()`, `getAvailablePurchases()`, `getPurchaseHistories()`, and all other StoreKit methods
+
+## Usage
+
+```typescript
+// Now works correctly during hot reload
+const [products, purchases] = await Promise.all([
+  requestProducts({skus: productIds}),
+  getAvailablePurchases(),
+]);
+```
+
+## Notes
+
+- iOS only (Android was not affected)
+- No performance impact
+- Requires expo-iap 2.7.7+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.7.6",
+  "version": "2.7.7-rc.1",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/useIap.ts
+++ b/src/useIap.ts
@@ -58,9 +58,15 @@ type UseIap = {
     skus: string[];
     type?: 'inapp' | 'subs';
   }) => Promise<void>;
-  /** @deprecated Use requestProducts({ skus, type: 'inapp' }) instead. This method will be removed in version 3.0.0. */
+  /** 
+   * @deprecated Use requestProducts({ skus, type: 'inapp' }) instead. This method will be removed in version 3.0.0.
+   * Note: This method internally uses requestProducts, so no deprecation warning is shown.
+   */
   getProducts: (skus: string[]) => Promise<void>;
-  /** @deprecated Use requestProducts({ skus, type: 'subs' }) instead. This method will be removed in version 3.0.0. */
+  /** 
+   * @deprecated Use requestProducts({ skus, type: 'subs' }) instead. This method will be removed in version 3.0.0.
+   * Note: This method internally uses requestProducts, so no deprecation warning is shown.
+   */
   getSubscriptions: (skus: string[]) => Promise<void>;
   requestPurchase: (params: {
     request: RequestPurchaseProps | RequestSubscriptionProps;


### PR DESCRIPTION
## Summary

This PR fixes race conditions on iOS when using concurrent StoreKit operations with `Promise.all` during hot reload.

## Problem

During hot reload, concurrent IAP operations would fail:
```typescript
await Promise.all([
  requestProducts({ skus: productIds }),
  getAvailablePurchases()  // Returns empty or fails
]);
```

## Solution

- Added proper state cleanup when `initConnection()` is called
- Implemented `ensureConnection()` pattern matching Android
- Fixed native module to handle hot reload state properly

## Changes

- **iOS Native Module**: Added state management and cleanup logic
- **Documentation**: Added guide for iOS hot reload fix
- **Changelog**: Updated with version 2.7.6 and 2.7.7 changes

## Testing

Tested on iOS device with hot reload enabled - concurrent operations now work correctly.


Resolve #130 