### PR TITLE
docs: improve iOS setup documentation based on user feedback

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD041": false,
+  "MD025": false
+}

--- a/docs/docs/getting-started/setup-ios.md
+++ b/docs/docs/getting-started/setup-ios.md
@@ -10,6 +10,27 @@ import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
 
 Setting up in-app purchases for iOS requires configuration in both Xcode and App Store Connect.
 
+## Prerequisites
+
+Before you can successfully implement and test in-app purchases, you must complete these essential steps in App Store Connect:
+
+### 1. Sign All Agreements
+
+1. Sign in to [App Store Connect](https://appstoreconnect.apple.com/)
+2. Navigate to **Business** section
+3. **Sign ALL pending agreements** - This is crucial!
+4. If agreements are not signed, products won't appear in your app
+
+### 2. Complete Banking, Legal, and Tax Information
+
+1. Go to **Business** > **Banking**
+2. Fill out **ALL** required banking information
+3. Complete **ALL** legal and tax forms
+4. **Wait for Apple's approval** - This can take several days
+5. Products will not be available until Apple approves all information
+
+> ⚠️ **Important**: These prerequisites are often overlooked but are absolutely essential. Without completing these steps, your products will not be found, even if everything else is configured correctly.
+
 ## App Store Connect Configuration
 
 ### 1. Create Your App Record
@@ -85,11 +106,15 @@ Make sure you have proper code signing set up:
 
 On your iOS device:
 
-1. Sign out of the App Store
-2. Go to **Settings** > **App Store**
-3. Sign out of your Apple ID
-4. Install your app via Xcode or TestFlight
-5. When prompted for App Store credentials, use your sandbox test user
+1. **Important**: You don't need to sign into the App Store app with your sandbox account
+2. Instead, use the dedicated sandbox login:
+   - Go to **Settings** > **Developer** (Developer mode must be enabled)
+   - Tap **Sandbox Apple Account**
+   - Sign in with your sandbox test user credentials
+3. Install your app via Xcode or TestFlight
+4. When making a purchase, it will automatically use the sandbox account
+
+> 💡 **Note**: This is the recommended approach starting from iOS 15+. The old method of signing into the App Store app with sandbox credentials is no longer necessary and can cause confusion.
 
 ## Code Integration
 
@@ -202,11 +227,23 @@ const handlePurchaseError = (error: any) => {
 
 ### Product IDs Not Found
 
-**Problem**: Products return empty or undefined **Solution**:
+**Problem**: Products return empty or undefined
 
-- Verify product IDs match exactly between code and App Store Connect
-- Ensure products are in "Ready to Submit" or "Approved" state
-- Check bundle identifier matches
+**Solutions**:
+
+1. **Check Prerequisites** (Most common cause):
+   - Verify ALL agreements are signed in App Store Connect > Business
+   - Ensure ALL banking, legal, and tax information is completed AND approved by Apple
+   - These are the most commonly overlooked requirements
+
+2. **Verify Product Configuration**:
+   - Product IDs match exactly between code and App Store Connect
+   - Products are in "Ready to Submit" or "Approved" state
+   - Bundle identifier matches
+
+3. **Use Proper Sandbox Testing**:
+   - Sign in via Settings > Developer > Sandbox Apple Account
+   - NOT through the App Store app
 
 ### Sandbox Testing Issues
 

--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -52,6 +52,17 @@ Yes! `expo-iap` works in both Expo managed and bare React Native projects. Howev
 
 In-app purchases require native modules that aren't available in Expo Go. You need to create a [custom development client](https://docs.expo.dev/development/create-development-builds/) or use a bare workflow.
 
+### Can I test in-app purchases with the development client?
+
+Yes! You can test in-app purchases using the Expo development client. Simply run:
+
+```bash
+npx expo run:ios --device  # For iOS
+npx expo run:android       # For Android
+```
+
+This will build and install the development client on your physical device where you can test in-app purchases. You don't need to upload to TestFlight or Google Play for basic testing, though those platforms are useful for more comprehensive testing scenarios.
+
 ### Do I need to configure anything in my app stores?
 
 Yes, you need to:
@@ -109,7 +120,7 @@ useEffect(() => {
 - Your App is in "Ready for Submission" or "TestFlight" status (not just created in App Store Connect)
 - The in-app purchase product is in "Approved" status
 - You are logged into the App Store on your test device with a real or sandbox Apple ID (not just simulator)
-- The app was installed via TestFlight, not `expo run:ios`
+- The app was installed via `expo run:ios --device` on a real device OR via TestFlight
 - Your bundle ID matches exactly (including case sensitivity) between your app and App Store Connect
 - Product IDs are correct and match exactly in code
 - You called `initConnection()` before `requestProducts()`


### PR DESCRIPTION
## Summary

This PR improves the iOS setup documentation based on real user feedback from Discord. It addresses common issues that users encounter when setting up in-app purchases on iOS.

## Changes

### 1. Enhanced iOS Setup Guide ()
- Added a prominent **Prerequisites** section highlighting critical App Store Connect requirements
- Emphasized that ALL agreements must be signed and ALL banking/legal/tax information must be completed AND approved by Apple
- Updated sandbox testing instructions to use the modern approach: Settings > Developer > Sandbox Apple Account
- Enhanced troubleshooting section to list prerequisites as the #1 cause of products not being found

### 2. Clarified Development Client Compatibility ()
- Fixed incorrect statement that said TestFlight was required instead of `expo run:ios`
- Clarified that EITHER `expo run:ios --device` OR TestFlight can be used for testing
- Added new FAQ section explicitly explaining that the development client works for testing IAPs

### 3. Added Markdown Lint Configuration
- Created `.markdownlint.json` to suppress MD041 and MD025 warnings in documentation files

## Context

These changes address issues raised by:
- Kirill: Who discovered that unsigned agreements and incomplete banking info were preventing products from appearing
- Henning Vogt: Who was confused by documentation suggesting TestFlight was required when the development client actually works fine

## Test Plan
- [x] Documentation builds successfully
- [x] All links are valid
- [x] Markdown formatting is correct