### PR TITLE
Fix acknowledgePurchaseAndroid argument mismatch

### DIFF
--- a/src/modules/android.ts
+++ b/src/modules/android.ts
@@ -90,12 +90,10 @@ export const validateReceiptAndroid = async ({
  */
 export const acknowledgePurchaseAndroid = ({
   token,
-  developerPayload,
 }: {
   token: string;
-  developerPayload?: string;
 }): Promise<PurchaseResult | boolean | void> => {
-  return ExpoIapModule.acknowledgePurchase(token, developerPayload);
+  return ExpoIapModule.acknowledgePurchase(token);
 };
 
 /**


### PR DESCRIPTION
Fixes #140 by removing unused developerPayload parameter that was causing argument count error.