### PR TITLE
fix: add packageName parameter to deepLinkToSubscriptionsAndroid

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -119,11 +119,17 @@ export const getStorefrontIOS = async (): Promise<string> => {
 };
 
 // Android-only functions (no Platform.OS check needed in Android module)
-export const deepLinkToSubscriptionsAndroid = async (
-  sku?: string,
-): Promise<void> => {
+export const deepLinkToSubscriptionsAndroid = async ({
+  sku,
+  packageName,
+}: {
+  sku: string;
+  packageName: string;
+}): Promise<void> => {
   // Android implementation
-  return ExpoIapModule.deepLinkToSubscriptions(sku);
+  return Linking.openURL(
+    `https://play.google.com/store/account/subscriptions?package=${packageName}&sku=${sku}`,
+  );
 };
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -705,18 +705,25 @@ export const validateReceipt = async (
 /**
  * Deeplinks to native interface that allows users to manage their subscriptions
  * @param options.skuAndroid - Required for Android to locate specific subscription (ignored on iOS)
+ * @param options.packageNameAndroid - Required for Android to identify your app (ignored on iOS)
  * 
  * @returns Promise that resolves when the deep link is successfully opened
  * 
- * @throws {Error} When called on unsupported platform or when `skuAndroid` is missing on Android
+ * @throws {Error} When called on unsupported platform or when required Android parameters are missing
  * 
  * @example
  * import { deepLinkToSubscriptions } from 'expo-iap';
  * 
  * // Works on both iOS and Android
- * await deepLinkToSubscriptions({ skuAndroid: 'your_subscription_sku' });
+ * await deepLinkToSubscriptions({ 
+ *   skuAndroid: 'your_subscription_sku',
+ *   packageNameAndroid: 'com.example.app'
+ * });
  */
-export const deepLinkToSubscriptions = (options: {skuAndroid: string}): Promise<void> => {
+export const deepLinkToSubscriptions = (options: {
+  skuAndroid?: string;
+  packageNameAndroid?: string;
+}): Promise<void> => {
   if (Platform.OS === 'ios') {
     return deepLinkToSubscriptionsIos();
   }
@@ -724,10 +731,18 @@ export const deepLinkToSubscriptions = (options: {skuAndroid: string}): Promise<
   if (Platform.OS === 'android') {
     if (!options.skuAndroid) {
       return Promise.reject(
-        new Error('SKU is required to locate subscription in Android Store'),
+        new Error('skuAndroid is required to locate subscription in Android Store'),
       );
     }
-    return deepLinkToSubscriptionsAndroid({sku: options.skuAndroid});
+    if (!options.packageNameAndroid) {
+      return Promise.reject(
+        new Error('packageNameAndroid is required to identify your app in Android Store'),
+      );
+    }
+    return deepLinkToSubscriptionsAndroid({
+      sku: options.skuAndroid,
+      packageName: options.packageNameAndroid,
+    });
   }
 
   return Promise.reject(new Error(`Unsupported platform: ${Platform.OS}`));

--- a/src/modules/android.ts
+++ b/src/modules/android.ts
@@ -22,16 +22,32 @@ export function isProductAndroid<T extends {platform?: string}>(
 
 /**
  * Deep link to subscriptions screen on Android.
- * @param {string} sku The product's SKU (on Android)
+ * @param {Object} params - The parameters object
+ * @param {string} params.sku - The product's SKU (on Android)
+ * @param {string} params.packageName - The package name of your Android app (e.g., 'com.example.app')
  * @returns {Promise<void>}
+ * 
+ * @example
+ * ```typescript
+ * await deepLinkToSubscriptionsAndroid({
+ *   sku: 'subscription_id',
+ *   packageName: 'com.example.app'
+ * });
+ * ```
  */
 export const deepLinkToSubscriptionsAndroid = async ({
   sku,
+  packageName,
 }: {
   sku: string;
+  packageName: string;
 }): Promise<void> => {
+  if (!packageName) {
+    throw new Error('packageName is required for deepLinkToSubscriptionsAndroid');
+  }
+  
   return Linking.openURL(
-    `https://play.google.com/store/account/subscriptions?package=${await ExpoIapModule.getPackageName()}&sku=${sku}`,
+    `https://play.google.com/store/account/subscriptions?package=${packageName}&sku=${sku}`,
   );
 };
 
@@ -39,11 +55,12 @@ export const deepLinkToSubscriptionsAndroid = async ({
  * Validate receipt for Android. NOTE: This method is here for debugging purposes only. Including
  * your access token in the binary you ship to users is potentially dangerous.
  * Use server side validation instead for your production builds
- * @param {string} packageName package name of your app.
- * @param {string} productId product id for your in app product.
- * @param {string} productToken token for your purchase (called 'token' in the API documentation).
- * @param {string} accessToken OAuth access token with androidpublisher scope. Required for authentication.
- * @param {boolean} isSub whether this is subscription or inapp. `true` for subscription.
+ * @param {Object} params - The parameters object
+ * @param {string} params.packageName - package name of your app.
+ * @param {string} params.productId - product id for your in app product.
+ * @param {string} params.productToken - token for your purchase (called 'token' in the API documentation).
+ * @param {string} params.accessToken - OAuth access token with androidpublisher scope. Required for authentication.
+ * @param {boolean} params.isSub - whether this is subscription or inapp. `true` for subscription.
  * @returns {Promise<ReceiptAndroid>}
  */
 export const validateReceiptAndroid = async ({
@@ -85,7 +102,8 @@ export const validateReceiptAndroid = async ({
 
 /**
  * Acknowledge a product (on Android.) No-op on iOS.
- * @param {string} token The product's token (on Android)
+ * @param {Object} params - The parameters object
+ * @param {string} params.token - The product's token (on Android)
  * @returns {Promise<PurchaseResult | void>}
  */
 export const acknowledgePurchaseAndroid = ({


### PR DESCRIPTION
## Summary
- Fix missing `getPackageName` method in native module
- Add `packageName` parameter to `deepLinkToSubscriptionsAndroid`

## Changes
- Update function signature to require packageName parameter
- Update cross-platform API to pass packageNameAndroid
- Update documentation

Fixes #148