### PR TITLE
fix: resolve type mismatches between iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # CHANGELOG
 
+## [2.8.1] - 2025-08-19
+
+### Added
+- Added `debugDescription?: string` field to `ProductCommon` for debugging purposes
+- Added `platform?: string` field to `ProductCommon` and `PurchaseCommon` for platform identification
+- Added `platform: "ios"` to iOS-specific types (`ProductIOS`, `ProductSubscriptionIOS`, `PurchaseIOS`)
+- Added `platform: "android"` to Android-specific types (`ProductAndroid`, `ProductSubscriptionAndroid`, `PurchaseAndroid`)
+- Added `ids?: string[]` field to `PurchaseCommon` (moved from Android-specific types)
+
+### Changed
+- Moved common fields from platform-specific types to shared Common types
+- Updated iOS native code to populate missing subscription fields:
+  - `introductoryPriceAsAmountIOS`
+  - `introductoryPricePaymentModeIOS`
+  - `introductoryPriceNumberOfPeriodsIOS`
+  - `introductoryPriceSubscriptionPeriodIOS`
+  - `subscriptionPeriodNumberIOS`
+  - `subscriptionPeriodUnitIOS`
+- Updated Android native code to use common `ids` field instead of platform-specific `idsAndroid`
+
+### Fixed
+- Fixed type mismatches between Product and Purchase types across iOS and Android platforms
+- Resolved missing field mappings in iOS native subscription data extraction
+- Improved type consistency for cross-platform compatibility
+
+### Deprecated
+**Note**: No breaking changes in this release. The following deprecated fields will be removed in v2.9.0:
+- Android: `idsAndroid` (use common `ids` field instead)
+- Android: `name`, `oneTimePurchaseOfferDetails`, `subscriptionOfferDetails` (use fields with `Android` suffix)
+- iOS: `displayName`, `isFamilyShareable`, `jsonRepresentation`, `subscription` (use fields with `IOS` suffix)
+- iOS: `discounts`, `introductoryPrice` (use fields with `IOS` suffix)
+
 ## [2.8.0] - 2025-08-18
 
 ### Breaking Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # Implementation Guidelines
 
+## Release Notes
+
+### v2.8.1 (2025-08-19)
+- Added `platform` field to all types for runtime type discrimination
+- Moved common fields to shared base types (`ids`, `debugDescription`)
+- Fixed iOS native code to populate missing subscription fields
+- No breaking changes, but deprecated fields will be removed in v2.9.0
+
+### v2.8.0 (2025-08-18)
+- **Breaking**: iOS field naming convention changed (e.g., `quantityIos` → `quantityIOS`)
+- All iOS-related field names ending with "Ios" now end with "IOS"
+
 ## Expo-Specific Guidelines
 
 ### Pre-Commit Checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,34 @@ Before committing any changes:
 
 ### Platform-Specific Naming Conventions
 
-- **iOS-related code**: Use `IOS` in naming (e.g., `PurchaseIOS`, `SubscriptionOfferIOS`)
+#### Field Naming
+- **iOS-related fields**: Use `IOS` suffix (e.g., `displayNameIOS`, `discountsIOS`, `introductoryPriceIOS`)
   - **Exception**: When an acronym appears at the end of a field name, use uppercase (e.g., `quantityIOS`, `appBundleIdIOS`, not `quantityIos`)
-- **Android-related code**: Use `Android` in naming (e.g., `PurchaseAndroid`, `SubscriptionOfferAndroid`)
-- **IAP-related code**: Use `Iap` in naming (e.g., `IapPurchase`, not `IAPPurchase`)
-- **ID fields**: Use `Id` instead of `ID` in field names (e.g., `productId`, `transactionId`, not `productID`, `transactionID`)
-  - This applies across all platforms for consistency
-  - Examples: `productId`, `originalTransactionId`, `purchaseId`
-- This applies to both functions, types, and file names
+  - Platform-specific fields: `currencyCodeIOS`, `currencySymbolIOS`, `countryCodeIOS`
+  - Product fields: `isFamilyShareableIOS`, `jsonRepresentationIOS`, `subscriptionInfoIOS`
+- **Android-related fields**: Use `Android` suffix (e.g., `nameAndroid`)
+  - Platform-specific fields: `oneTimePurchaseOfferDetailsAndroid`, `subscriptionOfferDetailsAndroid`
+  - Keep `pricingPhases` (not `pricingPhasesAndroid`) for consistency with Google Play Billing
+- **Common fields**: Fields shared across platforms go in Common types (e.g., `ids`, `platform`, `debugDescription`)
+  - Use these for data that exists on both platforms without platform-specific variations
+
+#### Type Naming
+- **iOS types**: Use `IOS` suffix (e.g., `PurchaseIOS`, `ProductIOS`)
+- **Android types**: Use descriptive prefixes to identify subtypes:
+  - ✅ Good: `ProductAndroidOneTimePurchaseOfferDetail`, `ProductSubscriptionAndroidOfferDetails`, `PurchaseAndroidState`
+  - ❌ Avoid: `OneTimePurchaseOfferDetails`, `SubscriptionOfferAndroid`, `PurchaseStateAndroid`
+- **General IAP types**: Use `Iap` prefix (e.g., `IapPurchase`, not `IAPPurchase`)
+
+#### General Rules
+- **ID fields**: Use `Id` instead of `ID` (e.g., `productId`, `transactionId`, not `productID`, `transactionID`)
+- **Consistent naming**: This applies to functions, types, and file names
+- **Deprecation**: Fields without platform suffixes will be removed in v2.9.0
+
+### Type System
+
+For complete type definitions and documentation, see: <https://www.openiap.dev/docs/types>
+
+The library follows the OpenIAP type specifications with platform-specific extensions using iOS/Android suffixes.
 
 ### React/JSX Conventions
 

--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -199,48 +199,65 @@ class ExpoIapModule :
                                     ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
                                     ?: "N/A"
 
+                                // Prepare reusable data
+                                val oneTimePurchaseData = productDetails.oneTimePurchaseOfferDetails?.let {
+                                    mapOf(
+                                        "priceCurrencyCode" to it.priceCurrencyCode,
+                                        "formattedPrice" to it.formattedPrice,
+                                        "priceAmountMicros" to it.priceAmountMicros.toString(),
+                                    )
+                                }
+                                
+                                val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
+                                    mapOf(
+                                        "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
+                                        "offerId" to subscriptionOfferDetailsItem.offerId,
+                                        "offerToken" to subscriptionOfferDetailsItem.offerToken,
+                                        "offerTags" to subscriptionOfferDetailsItem.offerTags,
+                                        "pricingPhases" to
+                                            mapOf(
+                                                "pricingPhaseList" to
+                                                    subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.map
+                                                        { pricingPhaseItem ->
+                                                            mapOf(
+                                                                "formattedPrice" to pricingPhaseItem.formattedPrice,
+                                                                "priceCurrencyCode" to pricingPhaseItem.priceCurrencyCode,
+                                                                "billingPeriod" to pricingPhaseItem.billingPeriod,
+                                                                "billingCycleCount" to pricingPhaseItem.billingCycleCount,
+                                                                "priceAmountMicros" to
+                                                                    pricingPhaseItem.priceAmountMicros.toString(),
+                                                                "recurrenceMode" to pricingPhaseItem.recurrenceMode,
+                                                            )
+                                                        },
+                                            ),
+                                    )
+                                }
+
+                                // Convert Android productType to our expected 'inapp' or 'subs'
+                                val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
+                                
                                 mapOf(
                                     "id" to productDetails.productId,
                                     "title" to productDetails.title,
                                     "description" to productDetails.description,
-                                    "type" to productDetails.productType,
-                                    "displayName" to productDetails.name,
+                                    "type" to productType,
+                                    // New field names with Android suffix
+                                    "nameAndroid" to productDetails.name,
+                                    "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseData,
+                                    "subscriptionOfferDetailsAndroid" to subscriptionOfferData,
                                     "platform" to "android",
                                     "currency" to currency,
                                     "displayPrice" to displayPrice,
-                                    "oneTimePurchaseOfferDetails" to
-                                        productDetails.oneTimePurchaseOfferDetails?.let {
-                                            mapOf(
-                                                "priceCurrencyCode" to it.priceCurrencyCode,
-                                                "formattedPrice" to it.formattedPrice,
-                                                "priceAmountMicros" to it.priceAmountMicros.toString(),
-                                            )
-                                        },
-                                    "subscriptionOfferDetails" to
-                                        productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
-                                            mapOf(
-                                                "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
-                                                "offerId" to subscriptionOfferDetailsItem.offerId,
-                                                "offerToken" to subscriptionOfferDetailsItem.offerToken,
-                                                "offerTags" to subscriptionOfferDetailsItem.offerTags,
-                                                "pricingPhases" to
-                                                    mapOf(
-                                                        "pricingPhaseList" to
-                                                            subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.map
-                                                                { pricingPhaseItem ->
-                                                                    mapOf(
-                                                                        "formattedPrice" to pricingPhaseItem.formattedPrice,
-                                                                        "priceCurrencyCode" to pricingPhaseItem.priceCurrencyCode,
-                                                                        "billingPeriod" to pricingPhaseItem.billingPeriod,
-                                                                        "billingCycleCount" to pricingPhaseItem.billingCycleCount,
-                                                                        "priceAmountMicros" to
-                                                                            pricingPhaseItem.priceAmountMicros.toString(),
-                                                                        "recurrenceMode" to pricingPhaseItem.recurrenceMode,
-                                                                    )
-                                                                },
-                                                    ),
-                                            )
-                                        },
+                                    // START: Deprecated - will be removed in v2.9.0
+                                    // Use nameAndroid instead of displayName
+                                    "displayName" to productDetails.name,
+                                    // Use nameAndroid instead of name
+                                    "name" to productDetails.name,
+                                    // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
+                                    "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
+                                    // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
+                                    "subscriptionOfferDetails" to subscriptionOfferData,
+                                    // END: Deprecated - will be removed in v2.9.0
                                 )
                             }
                         promise.resolve(items)

--- a/docs/blog/2025-07-23-v2-7-0-release.md
+++ b/docs/blog/2025-07-23-v2-7-0-release.md
@@ -163,7 +163,7 @@ const buySubscription = async (subId: string) => {
 {
   ios: {
     sku: string;                                        // Required: Product SKU
-    andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
+    andDangerouslyFinishTransactionAutomatically?: boolean;
     appAccountToken?: string;                           // For server validation
     quantity?: number;                                  // For bulk purchases
     withOffer?: PaymentDiscount;                        // For discounts

--- a/docs/blog/2025-08-19-v2-8-1-release.md
+++ b/docs/blog/2025-08-19-v2-8-1-release.md
@@ -1,0 +1,57 @@
+---
+slug: v2-8-1-release
+title: v2.8.1 Release - Type System Improvements
+authors: [hyochan]
+tags: [release, types, ios, android]
+---
+
+# expo-iap v2.8.1 Release
+
+This release resolves type mismatches between Product and Purchase types across iOS and Android platforms.
+
+## What's New
+
+### Type System Improvements
+
+- Added `platform` field to all types for runtime type discrimination
+- Moved common fields (`ids`, `debugDescription`) to shared base types
+- Fixed iOS native code to populate missing subscription fields
+
+### No Breaking Changes
+
+All existing code continues to work. Update to platform-specific field names before v2.9.0:
+
+- Android: `name` → `nameAndroid`
+- iOS: `displayName` → `displayNameIOS`
+
+## Important Note
+
+**If upgrading from versions before v2.8.0**, please review the [v2.8.0 migration guide](https://expo-iap.hyo.dev/blog/v2-8-0-migration-guide) first, as it contains breaking changes for iOS field naming conventions.
+
+## Type Discrimination Example
+
+```typescript
+import {Product, Purchase} from 'expo-iap';
+
+function handleProduct(product: Product) {
+  if (product.platform === 'ios') {
+    // TypeScript knows this is ProductIOS
+    console.log(product.isFamilyShareableIOS);
+  } else if (product.platform === 'android') {
+    // TypeScript knows this is ProductAndroid
+    console.log(product.nameAndroid);
+  }
+}
+```
+
+## Installation
+
+```bash
+npm install expo-iap@2.8.1
+```
+
+## Next Steps
+
+Deprecated fields will be removed in v2.9.0. Update your code now to ensure smooth migration.
+
+For details, see the [full changelog](https://github.com/hyochan/expo-iap/blob/main/CHANGELOG.md).

--- a/docs/docs/examples/basic-store.md
+++ b/docs/docs/examples/basic-store.md
@@ -54,7 +54,7 @@ await requestPurchase({
   request: {
     ios: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
     android: {
       skus: [productId],
@@ -72,7 +72,7 @@ await requestPurchase({
     ios: {
       sku: productId,
       // Set to false for manual transaction finishing
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
     android: {
       skus: [productId],
@@ -83,7 +83,7 @@ await requestPurchase({
 
 ### Key iOS Options
 
-- **`andDangerouslyFinishTransactionAutomaticallyIOS: false`**:
+- **`andDangerouslyFinishTransactionAutomatically: false`**:
   - **Recommended**: Set to `false` to manually handle transaction finishing
   - This allows proper receipt validation before completing the transaction
   - Prevents race conditions and ensures proper purchase flow

--- a/docs/docs/examples/complete-impl.md
+++ b/docs/docs/examples/complete-impl.md
@@ -44,8 +44,8 @@ useEffect(() => {
 
   const initializeStore = async () => {
     try {
-      await requestProducts({ skus: productSkus, type: 'inapp' });
-      await requestProducts({ skus: subscriptionSkus, type: 'subs' });
+      await requestProducts({skus: productSkus, type: 'inapp'});
+      await requestProducts({skus: subscriptionSkus, type: 'subs'});
     } catch (error) {
       console.error('Failed to initialize store:', error);
     }
@@ -65,7 +65,7 @@ const handlePurchase = async (productId) => {
       request: {
         ios: {
           sku: productId,
-          andDangerouslyFinishTransactionAutomaticallyIOS: false,
+          andDangerouslyFinishTransactionAutomatically: false,
         },
         android: {
           skus: [productId],
@@ -129,7 +129,7 @@ await requestPurchase({
   request: {
     ios: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false, // Important!
+      andDangerouslyFinishTransactionAutomatically: false, // Important!
     },
     android: {
       skus: [productId], // Android uses array
@@ -246,8 +246,8 @@ export default function Store() {
 
       // Load both products and subscriptions
       await Promise.all([
-        requestProducts({ skus: PRODUCT_IDS, type: 'inapp' }),
-        requestProducts({ skus: SUBSCRIPTION_IDS, type: 'subs' }),
+        requestProducts({skus: PRODUCT_IDS, type: 'inapp'}),
+        requestProducts({skus: SUBSCRIPTION_IDS, type: 'subs'}),
       ]);
 
       console.log('Products loaded successfully');
@@ -333,7 +333,7 @@ export default function Store() {
             sku: productId,
             // Important: Set to false to manually handle transaction finishing
             // This allows proper receipt validation before finishing the transaction
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
           android: {
             skus: [productId],
@@ -385,14 +385,14 @@ export default function Store() {
         // CRITICAL: Check required Android parameters before validation
         if (!purchaseToken || !packageName) {
           throw new Error(
-            'Android validation requires packageName and purchaseToken'
+            'Android validation requires packageName and purchaseToken',
           );
         }
 
         // Note: For server-side validation with Google Play API, you may also need:
         // - accessToken: OAuth2 token for accessing Google Play Developer API
         // This is typically handled server-side, not in the client app
-        
+
         const response = await fetch(
           'https://your-server.com/validate-receipt-android',
           {
@@ -676,7 +676,7 @@ await requestPurchase({
   request: {
     ios: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
     android: {
       skus: [productId],

--- a/docs/docs/examples/subscription-manager.md
+++ b/docs/docs/examples/subscription-manager.md
@@ -324,7 +324,7 @@ export default function SubscriptionManager() {
         request: {
           ios: {
             sku: productId,
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
           android: {
             skus: [productId],
@@ -686,7 +686,7 @@ await requestPurchase({
   request: {
     ios: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
     android: {
       skus: [productId],

--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -156,7 +156,7 @@ Users cannot cancel subscriptions within your app. You need to direct them to th
 import {deepLinkToSubscriptions} from 'expo-iap';
 
 const openSubscriptionManagement = () => {
-  deepLinkToSubscriptions({ skuAndroid: 'your_subscription_sku' });
+  deepLinkToSubscriptions({skuAndroid: 'your_subscription_sku'});
 };
 ```
 
@@ -442,7 +442,7 @@ These issues ([#114](https://github.com/hyochan/expo-iap/issues/114), [react-nat
 
 #### purchaseUpdatedListener is called twice after finishTransaction
 
-**Issue:** On iOS, `purchaseUpdatedListener` may be called twice for the same transaction when using `andDangerouslyFinishTransactionAutomaticallyIOS: false` and manually calling `finishTransaction()`.
+**Issue:** On iOS, `purchaseUpdatedListener` may be called twice for the same transaction when using `andDangerouslyFinishTransactionAutomatically: false` and manually calling `finishTransaction()`.
 
 **Symptoms:**
 
@@ -463,7 +463,7 @@ const purchaseListener = purchaseUpdatedListener(async (purchase) => {
 
 await requestPurchase({
   sku: 'your.product.id',
-  andDangerouslyFinishTransactionAutomaticallyIOS: false,
+  andDangerouslyFinishTransactionAutomatically: false,
 });
 ```
 

--- a/docs/docs/guides/migration.md
+++ b/docs/docs/guides/migration.md
@@ -183,7 +183,36 @@ const {
 } = useIAP();
 ```
 
-### 5. Update Error Handling
+### 5. Update to v2.8.1 Type System (Recommended)
+
+Starting from v2.8.1, expo-iap provides improved type consistency across platforms:
+
+**Platform Identification:**
+```tsx
+// v2.8.1+ includes platform fields for better type discrimination
+if (product.platform === 'ios') {
+  // TypeScript knows this is ProductIOS
+  console.log(product.isFamilyShareableIOS);
+} else if (product.platform === 'android') {
+  // TypeScript knows this is ProductAndroid
+  console.log(product.nameAndroid);
+}
+```
+
+**Common Fields:**
+```tsx
+// Before v2.8.1
+const ids = purchase.idsAndroid; // Android only
+
+// After v2.8.1
+const ids = purchase.ids; // Works for both platforms
+```
+
+**Note:** Deprecated fields will be removed in v2.9.0. Update your code to use platform-specific field names:
+- Android: Use fields with `Android` suffix (e.g., `nameAndroid` instead of `name`)
+- iOS: Use fields with `IOS` suffix (e.g., `displayNameIOS` instead of `displayName`)
+
+### 6. Update Error Handling
 
 Enhance error handling with the new error types:
 

--- a/docs/docs/guides/purchases.md
+++ b/docs/docs/guides/purchases.md
@@ -303,7 +303,7 @@ export default function PurchaseScreen() {
         request: {
           ios: {
             sku: productId,
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
           android: {
             skus: [productId],

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -273,7 +273,7 @@ useEffect(() => {
 - This issue primarily affects iOS because of how StoreKit handles transactions
 - Android requires acknowledgment within 3 days to prevent automatic refunds
 - The `isConsumable` parameter defaults to `false`, which is appropriate for subscriptions and non-consumable products
-- Never set `andDangerouslyFinishTransactionAutomaticallyIOS: true` unless you understand the implications
+- Never set `andDangerouslyFinishTransactionAutomatically: true` unless you understand the implications
 - Always implement proper transaction finishing in your purchase flow
 
 #### 2. Testing on simulators/emulators
@@ -359,7 +359,6 @@ const handleStoreUnavailable = () => {
 3. **Xcode version issues**:
 
    If you're experiencing issues like duplicate purchase events or other unexpected behavior:
-
    - **Solution**: Upgrade to Xcode 16.4 or later
    - **Known issues resolved**: [#114](https://github.com/hyochan/expo-iap/issues/114), [react-native-iap #2970](https://github.com/hyochan/react-native-iap/issues/2970)
    - **Symptoms of old Xcode versions**:

--- a/docs/versioned_docs/version-2.6/examples/basic-store.md
+++ b/docs/versioned_docs/version-2.6/examples/basic-store.md
@@ -53,7 +53,7 @@ This example shows how to implement a basic in-app purchase store using expo-iap
 await requestPurchase({
   request: {
     sku: productId,
-    andDangerouslyFinishTransactionAutomaticallyIOS: false,
+    andDangerouslyFinishTransactionAutomatically: false,
   },
 });
 ```
@@ -74,7 +74,7 @@ if (Platform.OS === 'ios') {
     request: {
       sku: productId,
       // Set to false for manual transaction finishing
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
   });
 } else {
@@ -86,7 +86,7 @@ if (Platform.OS === 'ios') {
 
 ### Key iOS Options
 
-- **`andDangerouslyFinishTransactionAutomaticallyIOS: false`**:
+- **`andDangerouslyFinishTransactionAutomatically: false`**:
   - **Recommended**: Set to `false` to manually handle transaction finishing
   - This allows proper receipt validation before completing the transaction
   - Prevents race conditions and ensures proper purchase flow

--- a/docs/versioned_docs/version-2.6/examples/complete-impl.md
+++ b/docs/versioned_docs/version-2.6/examples/complete-impl.md
@@ -66,7 +66,7 @@ const handlePurchase = async (productId) => {
       await requestPurchase({
         request: {
           sku: productId,
-          andDangerouslyFinishTransactionAutomaticallyIOS: false,
+          andDangerouslyFinishTransactionAutomatically: false,
         },
       });
     } /* Platform.OS === "android" */ else {
@@ -131,7 +131,7 @@ if (Platform.OS === 'ios') {
   await requestPurchase({
     request: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false, // Important!
+      andDangerouslyFinishTransactionAutomatically: false, // Important!
     },
   });
 } /* Platform.OS === "android" */ else {
@@ -338,7 +338,7 @@ export default function Store() {
             sku: productId,
             // Important: Set to false to manually handle transaction finishing
             // This allows proper receipt validation before finishing the transaction
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
         });
       } /* Platform.OS === "android" */ else {
@@ -393,14 +393,14 @@ export default function Store() {
         // CRITICAL: Check required Android parameters before validation
         if (!purchaseToken || !packageName) {
           throw new Error(
-            'Android validation requires packageName and purchaseToken'
+            'Android validation requires packageName and purchaseToken',
           );
         }
 
         // Note: For server-side validation with Google Play API, you may also need:
         // - accessToken: OAuth2 token for accessing Google Play Developer API
         // This is typically handled server-side, not in the client app
-        
+
         const response = await fetch(
           'https://your-server.com/validate-receipt-android',
           {
@@ -684,7 +684,7 @@ if (Platform.OS === 'ios') {
   await requestPurchase({
     request: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
   });
 } else {

--- a/docs/versioned_docs/version-2.6/examples/subscription-manager.md
+++ b/docs/versioned_docs/version-2.6/examples/subscription-manager.md
@@ -324,7 +324,7 @@ export default function SubscriptionManager() {
         await requestPurchase({
           request: {
             sku: productId,
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
           type: 'subs',
         });
@@ -686,7 +686,7 @@ const styles = StyleSheet.create({
 await requestPurchase({
   request: {
     sku: productId,
-    andDangerouslyFinishTransactionAutomaticallyIOS: false,
+    andDangerouslyFinishTransactionAutomatically: false,
   },
   type: 'subs',
 });
@@ -707,7 +707,7 @@ if (Platform.OS === 'ios') {
   await requestPurchase({
     request: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
     type: 'subs',
   });

--- a/docs/versioned_docs/version-2.6/guides/faq.md
+++ b/docs/versioned_docs/version-2.6/guides/faq.md
@@ -411,7 +411,7 @@ This happens when:
 
 ### [iOS] purchaseUpdatedListener is called twice after finishTransaction
 
-**Issue:** On iOS, `purchaseUpdatedListener` may be called twice for the same transaction when using `andDangerouslyFinishTransactionAutomaticallyIOS: false` and manually calling `finishTransaction()`.
+**Issue:** On iOS, `purchaseUpdatedListener` may be called twice for the same transaction when using `andDangerouslyFinishTransactionAutomatically: false` and manually calling `finishTransaction()`.
 
 **Symptoms:**
 
@@ -432,7 +432,7 @@ const purchaseListener = purchaseUpdatedListener(async (purchase) => {
 
 await requestPurchase({
   sku: 'your.product.id',
-  andDangerouslyFinishTransactionAutomaticallyIOS: false,
+  andDangerouslyFinishTransactionAutomatically: false,
 });
 ```
 

--- a/docs/versioned_docs/version-2.6/guides/purchases.md
+++ b/docs/versioned_docs/version-2.6/guides/purchases.md
@@ -274,7 +274,7 @@ export default function PurchaseScreen() {
         await requestPurchase({
           request: {
             sku: productId,
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
         });
       } else {

--- a/docs/versioned_docs/version-2.7/examples/basic-store.md
+++ b/docs/versioned_docs/version-2.7/examples/basic-store.md
@@ -53,7 +53,7 @@ This example shows how to implement a basic in-app purchase store using expo-iap
 await requestPurchase({
   request: {
     sku: productId,
-    andDangerouslyFinishTransactionAutomaticallyIOS: false,
+    andDangerouslyFinishTransactionAutomatically: false,
   },
 });
 ```
@@ -74,7 +74,7 @@ if (Platform.OS === 'ios') {
     request: {
       sku: productId,
       // Set to false for manual transaction finishing
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
   });
 } else {
@@ -86,7 +86,7 @@ if (Platform.OS === 'ios') {
 
 ### Key iOS Options
 
-- **`andDangerouslyFinishTransactionAutomaticallyIOS: false`**:
+- **`andDangerouslyFinishTransactionAutomatically: false`**:
   - **Recommended**: Set to `false` to manually handle transaction finishing
   - This allows proper receipt validation before completing the transaction
   - Prevents race conditions and ensures proper purchase flow

--- a/docs/versioned_docs/version-2.7/examples/complete-impl.md
+++ b/docs/versioned_docs/version-2.7/examples/complete-impl.md
@@ -66,7 +66,7 @@ const handlePurchase = async (productId) => {
       await requestPurchase({
         request: {
           sku: productId,
-          andDangerouslyFinishTransactionAutomaticallyIOS: false,
+          andDangerouslyFinishTransactionAutomatically: false,
         },
       });
     } /* Platform.OS === "android" */ else {
@@ -131,7 +131,7 @@ if (Platform.OS === 'ios') {
   await requestPurchase({
     request: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false, // Important!
+      andDangerouslyFinishTransactionAutomatically: false, // Important!
     },
   });
 } /* Platform.OS === "android" */ else {
@@ -338,7 +338,7 @@ export default function Store() {
             sku: productId,
             // Important: Set to false to manually handle transaction finishing
             // This allows proper receipt validation before finishing the transaction
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
         });
       } /* Platform.OS === "android" */ else {
@@ -393,14 +393,14 @@ export default function Store() {
         // CRITICAL: Check required Android parameters before validation
         if (!purchaseToken || !packageName) {
           throw new Error(
-            'Android validation requires packageName and purchaseToken'
+            'Android validation requires packageName and purchaseToken',
           );
         }
 
         // Note: For server-side validation with Google Play API, you may also need:
         // - accessToken: OAuth2 token for accessing Google Play Developer API
         // This is typically handled server-side, not in the client app
-        
+
         const response = await fetch(
           'https://your-server.com/validate-receipt-android',
           {
@@ -684,7 +684,7 @@ if (Platform.OS === 'ios') {
   await requestPurchase({
     request: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
   });
 } else {

--- a/docs/versioned_docs/version-2.7/examples/subscription-manager.md
+++ b/docs/versioned_docs/version-2.7/examples/subscription-manager.md
@@ -324,7 +324,7 @@ export default function SubscriptionManager() {
         await requestPurchase({
           request: {
             sku: productId,
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
           type: 'subs',
         });
@@ -685,7 +685,7 @@ const styles = StyleSheet.create({
 await requestPurchase({
   request: {
     sku: productId,
-    andDangerouslyFinishTransactionAutomaticallyIOS: false,
+    andDangerouslyFinishTransactionAutomatically: false,
   },
   type: 'subs',
 });
@@ -706,7 +706,7 @@ if (Platform.OS === 'ios') {
   await requestPurchase({
     request: {
       sku: productId,
-      andDangerouslyFinishTransactionAutomaticallyIOS: false,
+      andDangerouslyFinishTransactionAutomatically: false,
     },
     type: 'subs',
   });

--- a/docs/versioned_docs/version-2.7/guides/faq.md
+++ b/docs/versioned_docs/version-2.7/guides/faq.md
@@ -411,7 +411,7 @@ This happens when:
 
 ### [iOS] purchaseUpdatedListener is called twice after finishTransaction
 
-**Issue:** On iOS, `purchaseUpdatedListener` may be called twice for the same transaction when using `andDangerouslyFinishTransactionAutomaticallyIOS: false` and manually calling `finishTransaction()`.
+**Issue:** On iOS, `purchaseUpdatedListener` may be called twice for the same transaction when using `andDangerouslyFinishTransactionAutomatically: false` and manually calling `finishTransaction()`.
 
 **Symptoms:**
 
@@ -432,7 +432,7 @@ const purchaseListener = purchaseUpdatedListener(async (purchase) => {
 
 await requestPurchase({
   sku: 'your.product.id',
-  andDangerouslyFinishTransactionAutomaticallyIOS: false,
+  andDangerouslyFinishTransactionAutomatically: false,
 });
 ```
 

--- a/docs/versioned_docs/version-2.7/guides/purchases.md
+++ b/docs/versioned_docs/version-2.7/guides/purchases.md
@@ -274,7 +274,7 @@ export default function PurchaseScreen() {
         await requestPurchase({
           request: {
             sku: productId,
-            andDangerouslyFinishTransactionAutomaticallyIOS: false,
+            andDangerouslyFinishTransactionAutomatically: false,
           },
         });
       } else {

--- a/example/__mocks__/expo-clipboard.ts
+++ b/example/__mocks__/expo-clipboard.ts
@@ -1,0 +1,3 @@
+export const setStringAsync = jest.fn().mockResolvedValue(undefined);
+export const getStringAsync = jest.fn().mockResolvedValue('');
+export const hasStringAsync = jest.fn().mockResolvedValue(false);

--- a/example/__tests__/subscription-flow.test.tsx
+++ b/example/__tests__/subscription-flow.test.tsx
@@ -22,7 +22,7 @@ const createMockSubscription = (overrides = {}) => ({
   displayPrice: '$9.99',
   currency: 'USD',
   platform: 'ios',
-  subscription: {
+  subscriptionInfoIOS: {
     subscriptionPeriod: { unit: 'MONTH' },
     introductoryOffer: {
       paymentMode: 'FREETRIAL',
@@ -40,7 +40,7 @@ const createMockAndroidSubscription = () => ({
   description: 'Android Test Description',
   displayPrice: '$4.99',
   platform: 'android',
-  subscriptionOfferDetails: [
+  subscriptionOfferDetailsAndroid: [
     {
       pricingPhases: {
         pricingPhaseList: [

--- a/example/app/available-purchases.tsx
+++ b/example/app/available-purchases.tsx
@@ -81,7 +81,7 @@ export default function AvailablePurchases() {
     setLoading(true);
     try {
       console.log('Loading available purchases...');
-      await getAvailablePurchases();
+      await getAvailablePurchases([]);
       console.log('Available purchases request sent');
     } catch (error) {
       console.error('Error getting available purchases:', error);
@@ -101,7 +101,7 @@ export default function AvailablePurchases() {
       
       // Then load available purchases
       console.log('[AVAILABLE-PURCHASES] Loading available purchases...');
-      getAvailablePurchases().catch(error => {
+      getAvailablePurchases([]).catch(error => {
         console.warn('[AVAILABLE-PURCHASES] Failed to load available purchases:', error);
       });
     }

--- a/example/bun.lock
+++ b/example/bun.lock
@@ -4,12 +4,14 @@
     "": {
       "name": "expo-iap-example",
       "dependencies": {
-        "@expo/vector-icons": "^14.0.2",
+        "@expo/vector-icons": "~14.0.4",
+        "@preact/signals-react": "^3.2.1",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "expo": "~52.0.46",
         "expo-blur": "~14.0.3",
         "expo-build-properties": "~0.13.2",
+        "expo-clipboard": "~7.0.1",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
         "expo-haptics": "~14.0.1",
@@ -356,7 +358,7 @@
 
     "@expo/sudo-prompt": ["@expo/sudo-prompt@9.3.2", "", {}, "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw=="],
 
-    "@expo/vector-icons": ["@expo/vector-icons@14.1.0", "", { "peerDependencies": { "expo-font": "*", "react": "*", "react-native": "*" } }, "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ=="],
+    "@expo/vector-icons": ["@expo/vector-icons@14.0.4", "", { "dependencies": { "prop-types": "^15.8.1" } }, "sha512-+yKshcbpDfbV4zoXOgHxCwh7lkE9VVTT5T03OUlBsqfze1PLy6Hi4jp1vSb1GVbY6eskvMIivGVc9SKzIv0oEQ=="],
 
     "@expo/ws-tunnel": ["@expo/ws-tunnel@1.0.6", "", {}, "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q=="],
 
@@ -419,6 +421,10 @@
     "@npmcli/fs": ["@npmcli/fs@3.1.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@preact/signals-core": ["@preact/signals-core@1.11.0", "", {}, "sha512-jglbibeWHuFRzEWVFY/TT7wB1PppJxmcSfUHcK+2J9vBRtiooMfw6tAPttojNYrrpdGViqAYCbPpmWYlMm+eMQ=="],
+
+    "@preact/signals-react": ["@preact/signals-react@3.2.1", "", { "dependencies": { "@preact/signals-core": "^1.11.0", "use-sync-external-store": "^1.2.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-kRaWeKpT4tUKfcvUB0QldqQ1p/Xjg6cXDN3ubdVwnRrCie+95IXcaOaRHSLiAPgxwdOQYrgEjHe6ms46FtzQhQ=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
 
@@ -889,6 +895,8 @@
     "expo-blur": ["expo-blur@14.0.3", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-BL3xnqBJbYm3Hg9t/HjNjdeY7N/q8eK5tsLYxswWG1yElISWZmMvrXYekl7XaVCPfyFyz8vQeaxd7q74ZY3Wrw=="],
 
     "expo-build-properties": ["expo-build-properties@0.13.3", "", { "dependencies": { "ajv": "^8.11.0", "semver": "^7.6.0" }, "peerDependencies": { "expo": "*" } }, "sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg=="],
+
+    "expo-clipboard": ["expo-clipboard@7.0.1", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-rqYk0+WoqitPcPKxmMxSpLonX1E5Ije3LBYfnYMbH3xU5Gr8EAH9QnOWOi4BgahUPvcot6nbFEnx+DqARrmxKQ=="],
 
     "expo-constants": ["expo-constants@17.0.8", "", { "dependencies": { "@expo/config": "~10.0.11", "@expo/env": "~0.4.2" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg=="],
 
@@ -1909,8 +1917,6 @@
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
-
-    "expo/@expo/vector-icons": ["@expo/vector-icons@14.0.4", "", { "dependencies": { "prop-types": "^15.8.1" } }, "sha512-+yKshcbpDfbV4zoXOgHxCwh7lkE9VVTT5T03OUlBsqfze1PLy6Hi4jp1vSb1GVbY6eskvMIivGVc9SKzIv0oEQ=="],
 
     "expo-build-properties/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 

--- a/example/package.json
+++ b/example/package.json
@@ -13,12 +13,14 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.0.2",
+    "@expo/vector-icons": "~14.0.4",
+    "@preact/signals-react": "^3.2.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "expo": "~52.0.46",
     "expo-blur": "~14.0.3",
     "expo-build-properties": "~0.13.2",
+    "expo-clipboard": "~7.0.1",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-iap",
-  "version": "2.8.1",
+  "version": "2.8.0",
   "description": "In App Purchase module in Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -428,7 +428,7 @@ export const requestPurchase = (
 
     const {
       sku,
-      andDangerouslyFinishTransactionAutomaticallyIOS = false,
+      andDangerouslyFinishTransactionAutomatically = false,
       appAccountToken,
       quantity,
       withOffer,
@@ -438,7 +438,7 @@ export const requestPurchase = (
       const offer = offerToRecordIOS(withOffer);
       const purchase = await ExpoIapModule.buyProduct(
         sku,
-        andDangerouslyFinishTransactionAutomaticallyIOS,
+        andDangerouslyFinishTransactionAutomatically,
         appAccountToken,
         quantity ?? -1,
         offer,

--- a/src/types/ExpoIapAndroid.types.ts
+++ b/src/types/ExpoIapAndroid.types.ts
@@ -22,7 +22,7 @@ type PricingPhasesAndroid = {
 
 type ProductSubscriptionAndroidOfferDetail = {
   basePlanId: string;
-  offerId: string;
+  offerId: string | null;
   offerToken: string;
   offerTags: string[];
   pricingPhases: PricingPhasesAndroid;

--- a/src/types/ExpoIapAndroid.types.ts
+++ b/src/types/ExpoIapAndroid.types.ts
@@ -1,6 +1,6 @@
-import {PurchaseBase, ProductBase} from '../ExpoIap.types';
+import {PurchaseCommon, ProductCommon} from '../ExpoIap.types';
 
-type OneTimePurchaseOfferDetails = {
+type ProductAndroidOneTimePurchaseOfferDetail = {
   priceCurrencyCode: string;
   formattedPrice: string;
   priceAmountMicros: string;
@@ -20,7 +20,7 @@ type PricingPhasesAndroid = {
   pricingPhaseList: PricingPhaseAndroid[];
 };
 
-type SubscriptionOfferDetail = {
+type ProductSubscriptionAndroidOfferDetail = {
   basePlanId: string;
   offerId: string;
   offerToken: string;
@@ -28,13 +28,26 @@ type SubscriptionOfferDetail = {
   pricingPhases: PricingPhasesAndroid;
 };
 
-export type ProductAndroid = ProductBase & {
-  name: string;
-  oneTimePurchaseOfferDetails?: OneTimePurchaseOfferDetails;
-  subscriptionOfferDetails?: SubscriptionOfferDetail[];
+export type ProductAndroid = ProductCommon & {
+  nameAndroid: string;
+  oneTimePurchaseOfferDetailsAndroid?: ProductAndroidOneTimePurchaseOfferDetail;
+  platform: "android";
+  subscriptionOfferDetailsAndroid?: ProductSubscriptionAndroidOfferDetail[];
+  /**
+   * @deprecated Use `nameAndroid` instead. This field will be removed in v2.9.0.
+   */
+  name?: string;
+  /**
+   * @deprecated Use `oneTimePurchaseOfferDetailsAndroid` instead. This field will be removed in v2.9.0.
+   */
+  oneTimePurchaseOfferDetails?: ProductAndroidOneTimePurchaseOfferDetail;
+  /**
+   * @deprecated Use `subscriptionOfferDetailsAndroid` instead. This field will be removed in v2.9.0.
+   */
+  subscriptionOfferDetails?: ProductSubscriptionAndroidOfferDetail[];
 };
 
-type SubscriptionOfferAndroid = {
+type ProductSubscriptionAndroidOfferDetails = {
   basePlanId: string;
   offerId: string | null;
   offerToken: string;
@@ -42,9 +55,16 @@ type SubscriptionOfferAndroid = {
   offerTags: string[];
 };
 
-export type SubscriptionProductAndroid = ProductAndroid & {
-  subscriptionOfferDetails: SubscriptionOfferAndroid[];
+export type ProductSubscriptionAndroid = ProductAndroid & {
+  subscriptionOfferDetailsAndroid: ProductSubscriptionAndroidOfferDetails[];
+  /**
+   * @deprecated Use `subscriptionOfferDetailsAndroid` instead. This field will be removed in v2.9.0.
+   */
+  subscriptionOfferDetails?: ProductSubscriptionAndroidOfferDetails[];
 };
+
+// Legacy naming for backward compatibility
+export type SubscriptionProductAndroid = ProductSubscriptionAndroid;
 
 export type RequestPurchaseAndroidProps = {
   skus: string[];
@@ -110,14 +130,21 @@ export enum FeatureTypeAndroid {
   SUBSCRIPTIONS_UPDATE = 'SUBSCRIPTIONS_UPDATE',
 }
 
-export enum PurchaseStateAndroid {
+export enum PurchaseAndroidState {
   UNSPECIFIED_STATE = 0,
   PURCHASED = 1,
   PENDING = 2,
 }
 
-export type ProductPurchaseAndroid = PurchaseBase & {
-  ids?: string[];
+// Legacy naming for backward compatibility
+/**
+ * @deprecated Use `PurchaseAndroidState` instead. This enum will be removed in v2.9.0.
+ */
+export const PurchaseStateAndroid = PurchaseAndroidState;
+
+// Legacy naming for backward compatibility
+export type ProductPurchaseAndroid = PurchaseCommon & {
+  platform: "android";
   /**
    * @deprecated Use `purchaseToken` instead. This field will be removed in a future version.
    */
@@ -125,10 +152,29 @@ export type ProductPurchaseAndroid = PurchaseBase & {
   dataAndroid?: string;
   signatureAndroid?: string;
   autoRenewingAndroid?: boolean;
-  purchaseStateAndroid?: PurchaseStateAndroid;
+  purchaseStateAndroid?: PurchaseAndroidState;
   isAcknowledgedAndroid?: boolean;
   packageNameAndroid?: string;
   developerPayloadAndroid?: string;
   obfuscatedAccountIdAndroid?: string;
   obfuscatedProfileIdAndroid?: string;
 };
+
+// Preferred naming
+export type PurchaseAndroid = ProductPurchaseAndroid;
+
+// Legacy type aliases for backward compatibility
+/**
+ * @deprecated Use `ProductAndroidOneTimePurchaseOfferDetail` instead. This type will be removed in v2.9.0.
+ */
+export type OneTimePurchaseOfferDetails = ProductAndroidOneTimePurchaseOfferDetail;
+
+/**
+ * @deprecated Use `ProductSubscriptionAndroidOfferDetail` instead. This type will be removed in v2.9.0.
+ */
+export type SubscriptionOfferDetail = ProductSubscriptionAndroidOfferDetail;
+
+/**
+ * @deprecated Use `ProductSubscriptionAndroidOfferDetails` instead. This type will be removed in v2.9.0.
+ */
+export type SubscriptionOfferAndroid = ProductSubscriptionAndroidOfferDetails;

--- a/src/types/ExpoIapIOS.types.ts
+++ b/src/types/ExpoIapIOS.types.ts
@@ -1,4 +1,4 @@
-import {PurchaseBase, ProductBase} from '../ExpoIap.types';
+import {PurchaseCommon, ProductCommon} from '../ExpoIap.types';
 
 type SubscriptionIosPeriod = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR' | '';
 type PaymentMode = '' | 'FREETRIAL' | 'PAYASYOUGO' | 'PAYUPFRONT';
@@ -26,10 +26,27 @@ type SubscriptionInfo = {
   };
 };
 
-export type ProductIOS = ProductBase & {
-  displayName: string;
-  isFamilyShareable: boolean;
-  jsonRepresentation: string;
+export type ProductIOS = ProductCommon & {
+  displayNameIOS: string;
+  isFamilyShareableIOS: boolean;
+  jsonRepresentationIOS: string;
+  platform: "ios";
+  subscriptionInfoIOS?: SubscriptionInfo;
+  /**
+   * @deprecated Use `displayNameIOS` instead. This field will be removed in v2.9.0.
+   */
+  displayName?: string;
+  /**
+   * @deprecated Use `isFamilyShareableIOS` instead. This field will be removed in v2.9.0.
+   */
+  isFamilyShareable?: boolean;
+  /**
+   * @deprecated Use `jsonRepresentationIOS` instead. This field will be removed in v2.9.0.
+   */
+  jsonRepresentation?: string;
+  /**
+   * @deprecated Use `subscriptionInfoIOS` instead. This field will be removed in v2.9.0.
+   */
   subscription?: SubscriptionInfo;
   introductoryPriceNumberOfPeriodsIOS?: string;
   introductoryPriceSubscriptionPeriodIOS?: SubscriptionIosPeriod;
@@ -45,16 +62,28 @@ export type Discount = {
   subscriptionPeriod: string;
 };
 
-export type SubscriptionProductIOS = ProductIOS & {
-  discounts?: Discount[];
-  introductoryPrice?: string;
+export type ProductSubscriptionIOS = ProductIOS & {
+  discountsIOS?: Discount[];
+  introductoryPriceIOS?: string;
   introductoryPriceAsAmountIOS?: string;
   introductoryPricePaymentModeIOS?: PaymentMode;
   introductoryPriceNumberOfPeriodsIOS?: string;
   introductoryPriceSubscriptionPeriodIOS?: SubscriptionIosPeriod;
+  platform: "ios";
   subscriptionPeriodNumberIOS?: string;
   subscriptionPeriodUnitIOS?: SubscriptionIosPeriod;
+  /**
+   * @deprecated Use `discountsIOS` instead. This field will be removed in v2.9.0.
+   */
+  discounts?: Discount[];
+  /**
+   * @deprecated Use `introductoryPriceIOS` instead. This field will be removed in v2.9.0.
+   */
+  introductoryPrice?: string;
 };
+
+// Legacy naming for backward compatibility
+export type SubscriptionProductIOS = ProductSubscriptionIOS;
 
 export type PaymentDiscount = {
   /**
@@ -79,9 +108,9 @@ export type PaymentDiscount = {
   timestamp: number;
 };
 
-export type RequestPurchaseIOSProps = {
+export type RequestPurchaseIosProps = {
   sku: string;
-  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
+  andDangerouslyFinishTransactionAutomatically?: boolean;
   /**
    * UUID representing user account
    */
@@ -89,18 +118,6 @@ export type RequestPurchaseIOSProps = {
   quantity?: number;
   withOffer?: PaymentDiscount;
 };
-
-export type RequestSubscriptionIOSProps = RequestPurchaseIOSProps;
-
-/**
- * @deprecated Use RequestPurchaseIOSProps instead. This alias will be removed in v3.0.0.
- */
-export type RequestPurchaseIosProps = RequestPurchaseIOSProps;
-
-/**
- * @deprecated Use RequestSubscriptionIOSProps instead. This alias will be removed in v3.0.0.
- */
-export type RequestSubscriptionIosProps = RequestSubscriptionIOSProps;
 
 type SubscriptionStatus =
   | 'expired'
@@ -120,8 +137,10 @@ export type ProductStatusIOS = {
   renewalInfo?: RenewalInfo;
 };
 
-export type ProductPurchaseIOS = PurchaseBase & {
+// Legacy naming for backward compatibility
+export type ProductPurchaseIOS = PurchaseCommon & {
   // iOS basic fields
+  platform: "ios";
   quantityIOS?: number;
   originalTransactionDateIOS?: number;
   originalTransactionIdentifierIOS?: string;
@@ -146,14 +165,20 @@ export type ProductPurchaseIOS = PurchaseBase & {
     type: string;
     paymentMode: string;
   };
-  priceIOS?: number;
-  currencyIOS?: string;
+  // Price locale fields
+  currencyCodeIOS?: string;
+  currencySymbolIOS?: string;
+  countryCodeIOS?: string;
   /**
    * @deprecated Use `purchaseToken` instead. This field will be removed in a future version.
    * iOS 15+ JWS representation is now available through the `purchaseToken` field.
    */
   jwsRepresentationIOS?: string;
 };
+
+// Preferred naming
+export type PurchaseIOS = ProductPurchaseIOS;
+
 
 export type AppTransactionIOS = {
   appTransactionId?: string; // Only available in iOS 18.4+


### PR DESCRIPTION
## Summary
- Improve type system consistency across iOS and Android
- Fix missing iOS subscription field mappings
- No breaking changes

## Changes
- Add `platform` field to all types for runtime discrimination
- Move common fields to shared base types
- Fix iOS native code to populate subscription fields
- Update documentation and examples

## Migration
No breaking changes. Deprecated fields will be removed in v2.9.0.

See [release notes](https://github.com/hyochan/expo-iap/blob/release/v2.8.1/docs/blog/2025-08-19-v2-8-1-release.md) for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added platform field across products/purchases and shared common fields (ids, debugDescription).
  - iOS now exposes richer subscription data (intro pricing, period details); Android adds Android-suffixed product fields.
  - Example app: product/subscription detail modals with copy-to-clipboard; improved price display; signals-based UI.

- Bug Fixes
  - Resolved cross-platform type mismatches; fixed missing iOS subscription mappings.

- Documentation
  - New v2.8.1 release notes; updated guides/examples to use unified auto-finish flag; expanded naming conventions and migration guidance.

- Tests
  - Updated mocks and test data for new fields.

- Chores
  - Example app deps updated.

- Deprecated
  - Legacy field names slated for removal in v2.9.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->