### PR TITLE
docs: add plugin in installation step

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -42,6 +42,7 @@ After installing the package, you need to:
    {
      "expo": {
        "plugins": [
+         "expo-iap",
          [
            "expo-build-properties",
            {
@@ -118,6 +119,7 @@ Add the following to your `app.json`:
 {
   "expo": {
     "plugins": [
+      "expo-iap",
       [
         "expo-build-properties",
         {


### PR DESCRIPTION
- idk why document has missing plugin installation while expo-iap holds a withIAP plugin provided.
- so i added extra document in need of one of my co-worker got confused to add the plugin or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to include expo-iap as a plugin in app.json examples.
  * Added expo-iap as a separate plugin entry ahead of existing configuration to clarify placement.
  * Refreshed both example snippets for consistency and to help users enable in-app purchases.
  * No functional changes to the application; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->