### PR TITLE
Fix Android finishTransaction null error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   Product,
   Purchase,
   PurchaseError,
+  ErrorCode,
   PurchaseResult,
   RequestSubscriptionProps,
   RequestPurchaseProps,
@@ -576,7 +577,15 @@ export const finishTransaction = ({
         
         if (!token) {
           return Promise.reject(
-            new Error('Purchase token is required to finish transaction')
+            new PurchaseError(
+              '[expo-iap]: PurchaseError',
+              'Purchase token is required to finish transaction',
+              undefined,
+              undefined,
+              'E_DEVELOPER_ERROR' as ErrorCode,
+              androidPurchase.productId,
+              'android'
+            )
           );
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -570,12 +570,21 @@ export const finishTransaction = ({
       },
       android: async () => {
         const androidPurchase = purchase as PurchaseAndroid;
-
-        if (isConsumable) {
-          return ExpoIapModule.consumeProduct(androidPurchase.purchaseToken);
+        
+        // Use purchaseToken if available, fallback to purchaseTokenAndroid for backward compatibility
+        const token = androidPurchase.purchaseToken || androidPurchase.purchaseTokenAndroid;
+        
+        if (!token) {
+          return Promise.reject(
+            new Error('Purchase token is required to finish transaction')
+          );
         }
 
-        return ExpoIapModule.acknowledgePurchase(androidPurchase.purchaseToken);
+        if (isConsumable) {
+          return ExpoIapModule.consumeProduct(token);
+        }
+
+        return ExpoIapModule.acknowledgePurchase(token);
       },
     }) || (() => Promise.reject(new Error('Unsupported Platform')))
   )();

--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -1,7 +1,7 @@
 // External dependencies
 import {useCallback, useEffect, useState, useRef} from 'react';
 import {Platform} from 'react-native';
-import {Subscription} from 'expo-modules-core';
+import {EventSubscription} from 'expo-modules-core';
 
 // Internal modules
 import {
@@ -158,10 +158,10 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   }, [options]);
 
   const subscriptionsRef = useRef<{
-    purchaseUpdate?: Subscription;
-    purchaseError?: Subscription;
-    promotedProductsIOS?: Subscription;
-    promotedProductIOS?: Subscription;
+    purchaseUpdate?: EventSubscription;
+    purchaseError?: EventSubscription;
+    promotedProductsIOS?: EventSubscription;
+    promotedProductIOS?: EventSubscription;
   }>({});
 
   const subscriptionsRefState = useRef<SubscriptionProduct[]>([]);

--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -1,7 +1,7 @@
 // External dependencies
 import {useCallback, useEffect, useState, useRef} from 'react';
 import {Platform} from 'react-native';
-import {EventSubscription} from 'expo-modules-core';
+import {Subscription} from 'expo-modules-core';
 
 // Internal modules
 import {
@@ -158,10 +158,10 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   }, [options]);
 
   const subscriptionsRef = useRef<{
-    purchaseUpdate?: EventSubscription;
-    purchaseError?: EventSubscription;
-    promotedProductsIOS?: EventSubscription;
-    promotedProductIOS?: EventSubscription;
+    purchaseUpdate?: Subscription;
+    purchaseError?: Subscription;
+    promotedProductsIOS?: Subscription;
+    promotedProductIOS?: Subscription;
   }>({});
 
   const subscriptionsRefState = useRef<SubscriptionProduct[]>([]);


### PR DESCRIPTION
Fixes #170 #175

- Add fallback to purchaseTokenAndroid when purchaseToken is undefined
- Update expo-modules-core Subscription import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publicly export the ErrorCode type for easier error handling in apps.
* **Bug Fixes**
  * Improved reliability when finishing Android purchases by accepting tokens from multiple sources and applying the correct action for consumables vs. non‑consumables.
  * Added clear error feedback when a purchase token is missing.
  * Preserves compatibility with legacy Android purchase token fields.
  * No changes to iOS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->