### PR TITLE
refactor: drop Android ensureConnection; add iOS check

### DIFF
--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -584,7 +584,6 @@ class ExpoIapModule :
                         return@AsyncFunction
                     }
             }
-            }
 
             AsyncFunction("acknowledgePurchaseAndroid") {
                     token: String,

--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -669,6 +669,14 @@ class ExpoIapModule :
             )
             return null
         }
+        if (!client.isReady) {
+            promise.reject(
+                IapErrorCode.E_INIT_CONNECTION,
+                "BillingClient not ready. Wait for initConnection() to complete.",
+                null,
+            )
+            return null
+        }
         return client
     }
 

--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -249,16 +249,7 @@ class ExpoIapModule :
                                 "platform" to "android",
                                 "currency" to currency,
                                 "displayPrice" to displayPrice,
-                                // START: Deprecated - will be removed in v2.9.0
-                                // Use nameAndroid instead of displayName
-                                "displayName" to productDetails.name,
-                                // Use nameAndroid instead of name
-                                "name" to productDetails.name,
-                                // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
-                                "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
-                                // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
-                                "subscriptionOfferDetails" to subscriptionOfferData,
-                                // END: Deprecated - will be removed in v2.9.0
+                                    
                             )
                         }
                     promise.resolve(items)
@@ -361,16 +352,7 @@ class ExpoIapModule :
                                 "platform" to "android",
                                 "currency" to currency,
                                 "displayPrice" to displayPrice,
-                                // START: Deprecated - will be removed in v2.9.0
-                                // Use nameAndroid instead of displayName
-                                "displayName" to productDetails.name,
-                                // Use nameAndroid instead of name
-                                "name" to productDetails.name,
-                                // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
-                                "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
-                                // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
-                                "subscriptionOfferDetails" to subscriptionOfferData,
-                                // END: Deprecated - will be removed in v2.9.0
+                                    
                             )
                         }
                     promise.resolve(items)

--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -188,7 +188,7 @@ class ExpoIapModule :
                     }
 
                     val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
-                    
+
                     val items =
                         productDetailsList.map { productDetails ->
                             skus[productDetails.productId] = productDetails
@@ -208,7 +208,7 @@ class ExpoIapModule :
                                     "priceAmountMicros" to it.priceAmountMicros.toString(),
                                 )
                             }
-                            
+
                             val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
                                 mapOf(
                                     "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
@@ -236,7 +236,7 @@ class ExpoIapModule :
 
                             // Convert Android productType to our expected 'inapp' or 'subs'
                             val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
-                            
+
                             mapOf(
                                 "id" to productDetails.productId,
                                 "title" to productDetails.title,
@@ -249,7 +249,7 @@ class ExpoIapModule :
                                 "platform" to "android",
                                 "currency" to currency,
                                 "displayPrice" to displayPrice,
-                                    
+
                             )
                         }
                     promise.resolve(items)
@@ -291,7 +291,7 @@ class ExpoIapModule :
                     }
 
                     val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
-                    
+
                     val items =
                         productDetailsList.map { productDetails ->
                             skus[productDetails.productId] = productDetails
@@ -311,7 +311,7 @@ class ExpoIapModule :
                                     "priceAmountMicros" to it.priceAmountMicros.toString(),
                                 )
                             }
-                            
+
                             val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
                                 mapOf(
                                     "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
@@ -339,7 +339,7 @@ class ExpoIapModule :
 
                             // Convert Android productType to our expected 'inapp' or 'subs'
                             val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
-                            
+
                             mapOf(
                                 "id" to productDetails.productId,
                                 "title" to productDetails.title,
@@ -352,7 +352,7 @@ class ExpoIapModule :
                                 "platform" to "android",
                                 "currency" to currency,
                                 "displayPrice" to displayPrice,
-                                    
+
                             )
                         }
                     promise.resolve(items)
@@ -521,7 +521,7 @@ class ExpoIapModule :
                         val errorData = PlayUtils.getBillingResponseData(billingResult.responseCode)
                         var errorMessage = billingResult.debugMessage ?: errorData.message
                         var subResponseCode: Int? = null
-                        
+
                         // Check for sub-response codes (v8.0.0+)
                         try {
                             subResponseCode = billingResult.javaClass.getMethod("getSubResponseCode").invoke(billingResult) as? Int
@@ -535,7 +535,7 @@ class ExpoIapModule :
                         } catch (e: Exception) {
                             // Method doesn't exist in older versions, ignore
                         }
-                        
+
                         // Send error event to match iOS behavior
                         val errorMap = mutableMapOf<String, Any?>(
                             "responseCode" to billingResult.responseCode,
@@ -543,25 +543,25 @@ class ExpoIapModule :
                             "code" to errorData.code,
                             "message" to errorMessage
                         )
-                        
+
                         // Add product ID if available
                         if (skuArr.isNotEmpty()) {
                             errorMap["productId"] = skuArr.first()
                         }
-                        
+
                         // Add sub-response code if available
                         subResponseCode?.let {
                             if (it != 0) {
                                 errorMap["subResponseCode"] = it
                             }
                         }
-                        
+
                         try {
                             sendEvent(OpenIapEvent.PURCHASE_ERROR, errorMap.toMap())
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to send PURCHASE_ERROR event: ${e.message}")
                         }
-                        
+
                         promise.reject(errorData.code, errorMessage, null)
                         return@AsyncFunction
                     }

--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -155,268 +155,266 @@ class ExpoIapModule :
             }
 
             AsyncFunction("fetchProducts") { type: String, skuArr: Array<String>, promise: Promise ->
-                ensureConnection(promise) { billingClient ->
-                    val skuList =
-                        skuArr.map { sku ->
-                            QueryProductDetailsParams.Product
-                                .newBuilder()
-                                .setProductId(sku)
-                                .setProductType(type)
-                                .build()
-                        }
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
 
-                    if (skuList.isEmpty()) {
-                        promise.reject(IapErrorCode.E_EMPTY_SKU_LIST, "The SKU list is empty.", null)
-                        return@ensureConnection
+                val skuList =
+                    skuArr.map { sku ->
+                        QueryProductDetailsParams.Product
+                            .newBuilder()
+                            .setProductId(sku)
+                            .setProductType(type)
+                            .build()
                     }
 
-                    val params =
-                        QueryProductDetailsParams
-                            .newBuilder()
-                            .setProductList(skuList)
-                            .build()
+                if (skuList.isEmpty()) {
+                    promise.reject(IapErrorCode.E_EMPTY_SKU_LIST, "The SKU list is empty.", null)
+                    return@AsyncFunction
+                }
 
-                    billingClient.queryProductDetailsAsync(params) { billingResult: BillingResult, productDetailsResult: QueryProductDetailsResult ->
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            promise.reject(
-                                IapErrorCode.E_QUERY_PRODUCT,
-                                "Error querying product details: ${billingResult.debugMessage}",
-                                null,
-                            )
-                            return@queryProductDetailsAsync
-                        }
+                val params =
+                    QueryProductDetailsParams
+                        .newBuilder()
+                        .setProductList(skuList)
+                        .build()
 
-                        val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
-                        
-                        val items =
-                            productDetailsList.map { productDetails ->
-                                skus[productDetails.productId] = productDetails
+                billingClient.queryProductDetailsAsync(params) { billingResult: BillingResult, productDetailsResult: QueryProductDetailsResult ->
+                    if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                        promise.reject(
+                            IapErrorCode.E_QUERY_PRODUCT,
+                            "Error querying product details: ${billingResult.debugMessage}",
+                            null,
+                        )
+                        return@queryProductDetailsAsync
+                    }
 
-                                val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
-                                    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
-                                    ?: "Unknown"
-                                val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
-                                    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
-                                    ?: "N/A"
+                    val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
+                    
+                    val items =
+                        productDetailsList.map { productDetails ->
+                            skus[productDetails.productId] = productDetails
 
-                                // Prepare reusable data
-                                val oneTimePurchaseData = productDetails.oneTimePurchaseOfferDetails?.let {
-                                    mapOf(
-                                        "priceCurrencyCode" to it.priceCurrencyCode,
-                                        "formattedPrice" to it.formattedPrice,
-                                        "priceAmountMicros" to it.priceAmountMicros.toString(),
-                                    )
-                                }
-                                
-                                val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
-                                    mapOf(
-                                        "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
-                                        "offerId" to subscriptionOfferDetailsItem.offerId,
-                                        "offerToken" to subscriptionOfferDetailsItem.offerToken,
-                                        "offerTags" to subscriptionOfferDetailsItem.offerTags,
-                                        "pricingPhases" to
-                                            mapOf(
-                                                "pricingPhaseList" to
-                                                    subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.map
-                                                        { pricingPhaseItem ->
-                                                            mapOf(
-                                                                "formattedPrice" to pricingPhaseItem.formattedPrice,
-                                                                "priceCurrencyCode" to pricingPhaseItem.priceCurrencyCode,
-                                                                "billingPeriod" to pricingPhaseItem.billingPeriod,
-                                                                "billingCycleCount" to pricingPhaseItem.billingCycleCount,
-                                                                "priceAmountMicros" to
-                                                                    pricingPhaseItem.priceAmountMicros.toString(),
-                                                                "recurrenceMode" to pricingPhaseItem.recurrenceMode,
-                                                            )
-                                                        },
-                                            ),
-                                    )
-                                }
+                            val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
+                                ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
+                                ?: "Unknown"
+                            val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
+                                ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
+                                ?: "N/A"
 
-                                // Convert Android productType to our expected 'inapp' or 'subs'
-                                val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
-                                
+                            // Prepare reusable data
+                            val oneTimePurchaseData = productDetails.oneTimePurchaseOfferDetails?.let {
                                 mapOf(
-                                    "id" to productDetails.productId,
-                                    "title" to productDetails.title,
-                                    "description" to productDetails.description,
-                                    "type" to productType,
-                                    // New field names with Android suffix
-                                    "nameAndroid" to productDetails.name,
-                                    "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseData,
-                                    "subscriptionOfferDetailsAndroid" to subscriptionOfferData,
-                                    "platform" to "android",
-                                    "currency" to currency,
-                                    "displayPrice" to displayPrice,
-                                    // START: Deprecated - will be removed in v2.9.0
-                                    // Use nameAndroid instead of displayName
-                                    "displayName" to productDetails.name,
-                                    // Use nameAndroid instead of name
-                                    "name" to productDetails.name,
-                                    // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
-                                    "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
-                                    // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
-                                    "subscriptionOfferDetails" to subscriptionOfferData,
-                                    // END: Deprecated - will be removed in v2.9.0
+                                    "priceCurrencyCode" to it.priceCurrencyCode,
+                                    "formattedPrice" to it.formattedPrice,
+                                    "priceAmountMicros" to it.priceAmountMicros.toString(),
                                 )
                             }
-                        promise.resolve(items)
-                    }
+                            
+                            val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
+                                mapOf(
+                                    "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
+                                    "offerId" to subscriptionOfferDetailsItem.offerId,
+                                    "offerToken" to subscriptionOfferDetailsItem.offerToken,
+                                    "offerTags" to subscriptionOfferDetailsItem.offerTags,
+                                    "pricingPhases" to
+                                        mapOf(
+                                            "pricingPhaseList" to
+                                                subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.map
+                                                    { pricingPhaseItem ->
+                                                        mapOf(
+                                                            "formattedPrice" to pricingPhaseItem.formattedPrice,
+                                                            "priceCurrencyCode" to pricingPhaseItem.priceCurrencyCode,
+                                                            "billingPeriod" to pricingPhaseItem.billingPeriod,
+                                                            "billingCycleCount" to pricingPhaseItem.billingCycleCount,
+                                                            "priceAmountMicros" to
+                                                                pricingPhaseItem.priceAmountMicros.toString(),
+                                                            "recurrenceMode" to pricingPhaseItem.recurrenceMode,
+                                                        )
+                                                    },
+                                        ),
+                                )
+                            }
+
+                            // Convert Android productType to our expected 'inapp' or 'subs'
+                            val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
+                            
+                            mapOf(
+                                "id" to productDetails.productId,
+                                "title" to productDetails.title,
+                                "description" to productDetails.description,
+                                "type" to productType,
+                                // New field names with Android suffix
+                                "nameAndroid" to productDetails.name,
+                                "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseData,
+                                "subscriptionOfferDetailsAndroid" to subscriptionOfferData,
+                                "platform" to "android",
+                                "currency" to currency,
+                                "displayPrice" to displayPrice,
+                                // START: Deprecated - will be removed in v2.9.0
+                                // Use nameAndroid instead of displayName
+                                "displayName" to productDetails.name,
+                                // Use nameAndroid instead of name
+                                "name" to productDetails.name,
+                                // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
+                                "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
+                                // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
+                                "subscriptionOfferDetails" to subscriptionOfferData,
+                                // END: Deprecated - will be removed in v2.9.0
+                            )
+                        }
+                    promise.resolve(items)
                 }
             }
 
             AsyncFunction("requestProducts") { type: String, skuArr: Array<String>, promise: Promise ->
                 Log.w("ExpoIap", "WARNING: requestProducts is deprecated. Use fetchProducts instead. The 'request' prefix should only be used for event-based operations. This method will be removed in version 3.0.0.")
-                
-                ensureConnection(promise) { billingClient ->
-                    val skuList =
-                        skuArr.map { sku ->
-                            QueryProductDetailsParams.Product
-                                .newBuilder()
-                                .setProductId(sku)
-                                .setProductType(type)
-                                .build()
-                        }
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
 
-                    if (skuList.isEmpty()) {
-                        promise.reject(IapErrorCode.E_EMPTY_SKU_LIST, "The SKU list is empty.", null)
-                        return@ensureConnection
+                val skuList =
+                    skuArr.map { sku ->
+                        QueryProductDetailsParams.Product
+                            .newBuilder()
+                            .setProductId(sku)
+                            .setProductType(type)
+                            .build()
                     }
 
-                    val params =
-                        QueryProductDetailsParams
-                            .newBuilder()
-                            .setProductList(skuList)
-                            .build()
+                if (skuList.isEmpty()) {
+                    promise.reject(IapErrorCode.E_EMPTY_SKU_LIST, "The SKU list is empty.", null)
+                    return@AsyncFunction
+                }
 
-                    billingClient.queryProductDetailsAsync(params) { billingResult: BillingResult, productDetailsResult: QueryProductDetailsResult ->
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            promise.reject(
-                                IapErrorCode.E_QUERY_PRODUCT,
-                                "Error querying product details: ${billingResult.debugMessage}",
-                                null,
-                            )
-                            return@queryProductDetailsAsync
-                        }
+                val params =
+                    QueryProductDetailsParams
+                        .newBuilder()
+                        .setProductList(skuList)
+                        .build()
 
-                        val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
-                        
-                        val items =
-                            productDetailsList.map { productDetails ->
-                                skus[productDetails.productId] = productDetails
+                billingClient.queryProductDetailsAsync(params) { billingResult: BillingResult, productDetailsResult: QueryProductDetailsResult ->
+                    if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                        promise.reject(
+                            IapErrorCode.E_QUERY_PRODUCT,
+                            "Error querying product details: ${billingResult.debugMessage}",
+                            null,
+                        )
+                        return@queryProductDetailsAsync
+                    }
 
-                                val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
-                                    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
-                                    ?: "Unknown"
-                                val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
-                                    ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
-                                    ?: "N/A"
+                    val productDetailsList = productDetailsResult.productDetailsList ?: emptyList()
+                    
+                    val items =
+                        productDetailsList.map { productDetails ->
+                            skus[productDetails.productId] = productDetails
 
-                                // Prepare reusable data
-                                val oneTimePurchaseData = productDetails.oneTimePurchaseOfferDetails?.let {
-                                    mapOf(
-                                        "priceCurrencyCode" to it.priceCurrencyCode,
-                                        "formattedPrice" to it.formattedPrice,
-                                        "priceAmountMicros" to it.priceAmountMicros.toString(),
-                                    )
-                                }
-                                
-                                val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
-                                    mapOf(
-                                        "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
-                                        "offerId" to subscriptionOfferDetailsItem.offerId,
-                                        "offerToken" to subscriptionOfferDetailsItem.offerToken,
-                                        "offerTags" to subscriptionOfferDetailsItem.offerTags,
-                                        "pricingPhases" to
-                                            mapOf(
-                                                "pricingPhaseList" to
-                                                    subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.map
-                                                        { pricingPhaseItem ->
-                                                            mapOf(
-                                                                "formattedPrice" to pricingPhaseItem.formattedPrice,
-                                                                "priceCurrencyCode" to pricingPhaseItem.priceCurrencyCode,
-                                                                "billingPeriod" to pricingPhaseItem.billingPeriod,
-                                                                "billingCycleCount" to pricingPhaseItem.billingCycleCount,
-                                                                "priceAmountMicros" to
-                                                                    pricingPhaseItem.priceAmountMicros.toString(),
-                                                                "recurrenceMode" to pricingPhaseItem.recurrenceMode,
-                                                            )
-                                                        },
-                                            ),
-                                    )
-                                }
+                            val currency = productDetails.oneTimePurchaseOfferDetails?.priceCurrencyCode
+                                ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.priceCurrencyCode
+                                ?: "Unknown"
+                            val displayPrice = productDetails.oneTimePurchaseOfferDetails?.formattedPrice
+                                ?: productDetails.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice
+                                ?: "N/A"
 
-                                // Convert Android productType to our expected 'inapp' or 'subs'
-                                val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
-                                
+                            // Prepare reusable data
+                            val oneTimePurchaseData = productDetails.oneTimePurchaseOfferDetails?.let {
                                 mapOf(
-                                    "id" to productDetails.productId,
-                                    "title" to productDetails.title,
-                                    "description" to productDetails.description,
-                                    "type" to productType,
-                                    // New field names with Android suffix
-                                    "nameAndroid" to productDetails.name,
-                                    "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseData,
-                                    "subscriptionOfferDetailsAndroid" to subscriptionOfferData,
-                                    "platform" to "android",
-                                    "currency" to currency,
-                                    "displayPrice" to displayPrice,
-                                    // START: Deprecated - will be removed in v2.9.0
-                                    // Use nameAndroid instead of displayName
-                                    "displayName" to productDetails.name,
-                                    // Use nameAndroid instead of name
-                                    "name" to productDetails.name,
-                                    // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
-                                    "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
-                                    // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
-                                    "subscriptionOfferDetails" to subscriptionOfferData,
-                                    // END: Deprecated - will be removed in v2.9.0
+                                    "priceCurrencyCode" to it.priceCurrencyCode,
+                                    "formattedPrice" to it.formattedPrice,
+                                    "priceAmountMicros" to it.priceAmountMicros.toString(),
                                 )
                             }
-                        promise.resolve(items)
-                    }
+                            
+                            val subscriptionOfferData = productDetails.subscriptionOfferDetails?.map { subscriptionOfferDetailsItem ->
+                                mapOf(
+                                    "basePlanId" to subscriptionOfferDetailsItem.basePlanId,
+                                    "offerId" to subscriptionOfferDetailsItem.offerId,
+                                    "offerToken" to subscriptionOfferDetailsItem.offerToken,
+                                    "offerTags" to subscriptionOfferDetailsItem.offerTags,
+                                    "pricingPhases" to
+                                        mapOf(
+                                            "pricingPhaseList" to
+                                                subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.map
+                                                    { pricingPhaseItem ->
+                                                        mapOf(
+                                                            "formattedPrice" to pricingPhaseItem.formattedPrice,
+                                                            "priceCurrencyCode" to pricingPhaseItem.priceCurrencyCode,
+                                                            "billingPeriod" to pricingPhaseItem.billingPeriod,
+                                                            "billingCycleCount" to pricingPhaseItem.billingCycleCount,
+                                                            "priceAmountMicros" to
+                                                                pricingPhaseItem.priceAmountMicros.toString(),
+                                                            "recurrenceMode" to pricingPhaseItem.recurrenceMode,
+                                                        )
+                                                    },
+                                        ),
+                                )
+                            }
+
+                            // Convert Android productType to our expected 'inapp' or 'subs'
+                            val productType = if (productDetails.productType == BillingClient.ProductType.SUBS) "subs" else "inapp"
+                            
+                            mapOf(
+                                "id" to productDetails.productId,
+                                "title" to productDetails.title,
+                                "description" to productDetails.description,
+                                "type" to productType,
+                                // New field names with Android suffix
+                                "nameAndroid" to productDetails.name,
+                                "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseData,
+                                "subscriptionOfferDetailsAndroid" to subscriptionOfferData,
+                                "platform" to "android",
+                                "currency" to currency,
+                                "displayPrice" to displayPrice,
+                                // START: Deprecated - will be removed in v2.9.0
+                                // Use nameAndroid instead of displayName
+                                "displayName" to productDetails.name,
+                                // Use nameAndroid instead of name
+                                "name" to productDetails.name,
+                                // Use oneTimePurchaseOfferDetailsAndroid instead of oneTimePurchaseOfferDetails
+                                "oneTimePurchaseOfferDetails" to oneTimePurchaseData,
+                                // Use subscriptionOfferDetailsAndroid instead of subscriptionOfferDetails
+                                "subscriptionOfferDetails" to subscriptionOfferData,
+                                // END: Deprecated - will be removed in v2.9.0
+                            )
+                        }
+                    promise.resolve(items)
                 }
             }
 
             AsyncFunction("getAvailableItemsByType") { type: String, promise: Promise ->
-                ensureConnection(promise) { billingClient ->
-                    val items = mutableListOf<Map<String, Any?>>()
-                    billingClient.queryPurchasesAsync(
-                        QueryPurchasesParams
-                            .newBuilder()
-                            .setProductType(
-                                if (type == "subs") BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP,
-                            ).build(),
-                    ) { billingResult: BillingResult, purchases: List<Purchase>? ->
-                        if (!isValidResult(billingResult, promise)) return@queryPurchasesAsync
-                        purchases?.forEach { purchase ->
-                            val item =
-                                mutableMapOf<String, Any?>(
-                                    "id" to purchase.orderId,
-                                    "productId" to purchase.products.firstOrNull() as Any?,
-                                    "ids" to purchase.products,
-                                    "transactionId" to purchase.orderId, // @deprecated - use id instead
-                                    "transactionDate" to purchase.purchaseTime.toDouble(),
-                                    "transactionReceipt" to purchase.originalJson,
-                                    "orderId" to purchase.orderId,
-                                    "purchaseTokenAndroid" to purchase.purchaseToken,
-                                    "purchaseToken" to purchase.purchaseToken,
-                                    "developerPayloadAndroid" to purchase.developerPayload,
-                                    "signatureAndroid" to purchase.signature,
-                                    "purchaseStateAndroid" to purchase.purchaseState,
-                                    "isAcknowledgedAndroid" to purchase.isAcknowledged,
-                                    "packageNameAndroid" to purchase.packageName,
-                                    "obfuscatedAccountIdAndroid" to purchase.accountIdentifiers?.obfuscatedAccountId,
-                                    "obfuscatedProfileIdAndroid" to purchase.accountIdentifiers?.obfuscatedProfileId,
-                                    "platform" to "android",
-                                )
-                            if (type == BillingClient.ProductType.SUBS) {
-                                item["autoRenewingAndroid"] = purchase.isAutoRenewing
-                            }
-                            items.add(item)
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
+                val items = mutableListOf<Map<String, Any?>>()
+                billingClient.queryPurchasesAsync(
+                    QueryPurchasesParams
+                        .newBuilder()
+                        .setProductType(
+                            if (type == "subs") BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP,
+                        ).build(),
+                ) { billingResult: BillingResult, purchases: List<Purchase>? ->
+                    if (!isValidResult(billingResult, promise)) return@queryPurchasesAsync
+                    purchases?.forEach { purchase ->
+                        val item =
+                            mutableMapOf<String, Any?>(
+                                "id" to purchase.orderId,
+                                "productId" to purchase.products.firstOrNull() as Any?,
+                                "ids" to purchase.products,
+                                "transactionId" to purchase.orderId, // @deprecated - use id instead
+                                "transactionDate" to purchase.purchaseTime.toDouble(),
+                                "transactionReceipt" to purchase.originalJson,
+                                "orderId" to purchase.orderId,
+                                "purchaseTokenAndroid" to purchase.purchaseToken,
+                                "purchaseToken" to purchase.purchaseToken,
+                                "developerPayloadAndroid" to purchase.developerPayload,
+                                "signatureAndroid" to purchase.signature,
+                                "purchaseStateAndroid" to purchase.purchaseState,
+                                "isAcknowledgedAndroid" to purchase.isAcknowledged,
+                                "packageNameAndroid" to purchase.packageName,
+                                "obfuscatedAccountIdAndroid" to purchase.accountIdentifiers?.obfuscatedAccountId,
+                                "obfuscatedProfileIdAndroid" to purchase.accountIdentifiers?.obfuscatedProfileId,
+                                "platform" to "android",
+                            )
+                        if (type == BillingClient.ProductType.SUBS) {
+                            item["autoRenewingAndroid"] = purchase.isAutoRenewing
                         }
-                        promise.resolve(items)
+                        items.add(item)
                     }
+                    promise.resolve(items)
                 }
             }
 
@@ -443,7 +441,7 @@ class ExpoIapModule :
                     return@AsyncFunction
                 }
 
-                ensureConnection(promise) { billingClient ->
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
                     PromiseUtils.addPromiseForKey(IapConstants.PROMISE_BUY_ITEM, promise)
 
                     if (type == BillingClient.ProductType.SUBS && skuArr.size != offerTokenArr.size) {
@@ -461,7 +459,7 @@ class ExpoIapModule :
                             Log.e(TAG, "Failed to send PURCHASE_ERROR event: ${e.message}")
                         }
                         promise.reject(IapErrorCode.E_SKU_OFFER_MISMATCH, debugMessage, null)
-                        return@ensureConnection
+                        return@AsyncFunction
                     }
 
                     val productParamsList =
@@ -484,7 +482,7 @@ class ExpoIapModule :
                                     Log.e(TAG, "Failed to send PURCHASE_ERROR event: ${e.message}")
                                 }
                                 promise.reject(IapErrorCode.E_SKU_NOT_FOUND, debugMessage, null)
-                                return@ensureConnection
+                                return@AsyncFunction
                             }
 
                             val productDetailParams =
@@ -583,17 +581,16 @@ class ExpoIapModule :
                         }
                         
                         promise.reject(errorData.code, errorMessage, null)
-                        return@ensureConnection
+                        return@AsyncFunction
                     }
-                }
+            }
             }
 
             AsyncFunction("acknowledgePurchaseAndroid") {
                     token: String,
                     promise: Promise,
                 ->
-
-                ensureConnection(promise) { billingClient ->
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
                     val acknowledgePurchaseParams =
                         AcknowledgePurchaseParams
                             .newBuilder()
@@ -617,7 +614,6 @@ class ExpoIapModule :
                         map["message"] = errorData.message
                         promise.resolve(map)
                     }
-                }
             }
 
             AsyncFunction("consumeProductAndroid") {
@@ -627,25 +623,24 @@ class ExpoIapModule :
 
                 val params = ConsumeParams.newBuilder().setPurchaseToken(token).build()
 
-                ensureConnection(promise) { billingClient ->
-                    billingClient.consumeAsync(params) { billingResult: BillingResult, purchaseToken: String? ->
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            PlayUtils.rejectPromiseWithBillingError(
-                                promise,
-                                billingResult.responseCode,
-                            )
-                            return@consumeAsync
-                        }
-
-                        val map = mutableMapOf<String, Any?>()
-                        map["responseCode"] = billingResult.responseCode
-                        map["debugMessage"] = billingResult.debugMessage
-                        val errorData = PlayUtils.getBillingResponseData(billingResult.responseCode)
-                        map["code"] = errorData.code
-                        map["message"] = errorData.message
-                        map["purchaseTokenAndroid"] = purchaseToken
-                        promise.resolve(map)
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
+                billingClient.consumeAsync(params) { billingResult: BillingResult, purchaseToken: String? ->
+                    if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                        PlayUtils.rejectPromiseWithBillingError(
+                            promise,
+                            billingResult.responseCode,
+                        )
+                        return@consumeAsync
                     }
+
+                    val map = mutableMapOf<String, Any?>()
+                    map["responseCode"] = billingResult.responseCode
+                    map["debugMessage"] = billingResult.debugMessage
+                    val errorData = PlayUtils.getBillingResponseData(billingResult.responseCode)
+                    map["code"] = errorData.code
+                    map["message"] = errorData.message
+                    map["purchaseTokenAndroid"] = purchaseToken
+                    promise.resolve(map)
                 }
             }
 
@@ -653,19 +648,18 @@ class ExpoIapModule :
             AsyncFunction("getStorefront") {
                     promise: Promise,
                 ->
-                ensureConnection(promise) { billingClient ->
-                    billingClient.getBillingConfigAsync(
-                        GetBillingConfigParams.newBuilder().build(),
-                        BillingConfigResponseListener { result: BillingResult, config: BillingConfig? ->
-                            if (result.responseCode == BillingClient.BillingResponseCode.OK) {
-                                promise.safeResolve(config?.countryCode.orEmpty())
-                            } else {
-                                val debugMessage = result.debugMessage.orEmpty()
-                                promise.safeReject(result.responseCode.toString(), debugMessage)
-                            }
-                        },
-                    )
-                }
+                val billingClient = getBillingClientOrReject(promise) ?: return@AsyncFunction
+                billingClient.getBillingConfigAsync(
+                    GetBillingConfigParams.newBuilder().build(),
+                    BillingConfigResponseListener { result: BillingResult, config: BillingConfig? ->
+                        if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                            promise.safeResolve(config?.countryCode.orEmpty())
+                        } else {
+                            val debugMessage = result.debugMessage.orEmpty()
+                            promise.safeReject(result.responseCode.toString(), debugMessage)
+                        }
+                    },
+                )
             }
         }
 
@@ -684,18 +678,17 @@ class ExpoIapModule :
         return true
     }
 
-    private fun ensureConnection(
-        promise: Promise,
-        callback: (billingClient: BillingClient) -> Unit,
-    ) {
-        // With auto-reconnection enabled, we only need to check if billing client exists
-        // The service will automatically reconnect when needed
-        if (billingClientCache != null) {
-            callback(billingClientCache!!)
-            return
+    private fun getBillingClientOrReject(promise: Promise): BillingClient? {
+        val client = billingClientCache
+        if (client == null) {
+            promise.reject(
+                IapErrorCode.E_INIT_CONNECTION,
+                "Connection not initialized. Call initConnection() first.",
+                null,
+            )
+            return null
         }
-
-        initBillingClient(promise, callback)
+        return client
     }
 
     private fun initBillingClient(

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -85,6 +85,7 @@ public class ExpoIapModule: Module {
         // MARK: - Product Management
         
         AsyncFunction("fetchProducts") { (params: [String: Any]) async throws -> [[String: Any?]] in
+            try ensureConnection()
             logDebug("fetchProducts raw params: \(params)")
             
             // Handle both object format {skus: [...], type: "..."} and array format
@@ -153,6 +154,7 @@ public class ExpoIapModule: Module {
             guard let sku = params["sku"] as? String, !sku.isEmpty else {
                 throw OpenIapError.make(code: OpenIapError.E_PURCHASE_ERROR, message: "Missing required 'sku'")
             }
+            try ensureConnection()
 
             // Optional fields
             let andFinish = (params["andDangerouslyFinishTransactionAutomatically"] as? Bool) ?? false
@@ -210,6 +212,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("finishTransaction") { (transactionId: String) async throws -> Bool in
+            try ensureConnection()
             logDebug("finishTransaction called with id: \(transactionId)")
             let result = try await OpenIapModule.shared.finishTransaction(transactionIdentifier: transactionId)
             return result
@@ -218,6 +221,7 @@ public class ExpoIapModule: Module {
         // MARK: - Purchase History
         
         AsyncFunction("getAvailablePurchases") { (options: [String: Any?]?) async throws -> [[String: Any?]] in
+            try ensureConnection()
             logDebug("getAvailablePurchases called")
             
             // Build options and get purchases directly from OpenIapModule
@@ -233,6 +237,7 @@ public class ExpoIapModule: Module {
         
         // Legacy function for backward compatibility
         AsyncFunction("getAvailableItems") { (alsoPublishToEventListener: Bool, onlyIncludeActiveItems: Bool) async throws -> [[String: Any?]] in
+            try ensureConnection()
             logDebug("getAvailableItems called (legacy)")
             
             let purchaseOptions = OpenIapGetAvailablePurchasesProps(
@@ -244,6 +249,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("getPendingTransactionsIOS") { () async throws -> [[String: Any?]] in
+            try ensureConnection()
             logDebug("getPendingTransactionsIOS called")
             
             let pendingTransactions = try await OpenIapModule.shared.getPendingTransactionsIOS()
@@ -251,6 +257,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("clearTransactionIOS") { () async throws -> Bool in
+            try ensureConnection()
             logDebug("clearTransactionIOS called")
             try await OpenIapModule.shared.clearTransactionIOS()
             return true
@@ -259,17 +266,20 @@ public class ExpoIapModule: Module {
         // MARK: - Receipt & Validation
         
         AsyncFunction("getReceiptIOS") { () async throws -> String in
+            try ensureConnection()
             logDebug("getReceiptIOS called")
             return try await OpenIapModule.shared.getReceiptDataIOS() ?? ""
         }
         
         AsyncFunction("requestReceiptRefreshIOS") { () async throws -> String in
+            try ensureConnection()
             logDebug("requestReceiptRefreshIOS called")
             // Receipt refresh is handled automatically by StoreKit 2
             return try await OpenIapModule.shared.getReceiptDataIOS() ?? ""
         }
         
         AsyncFunction("validateReceiptIOS") { (sku: String) async throws -> [String: Any?] in
+            try ensureConnection()
             logDebug("validateReceiptIOS called for sku: \(sku)")
             do {
                 // Use OpenIapReceiptValidationProps to keep naming parity with OpenIAP
@@ -291,12 +301,14 @@ public class ExpoIapModule: Module {
         // MARK: - iOS Specific Features
         
         AsyncFunction("presentCodeRedemptionSheetIOS") { () async throws -> Bool in
+            try ensureConnection()
             logDebug("presentCodeRedemptionSheetIOS called")
             let _ = try await OpenIapModule.shared.presentCodeRedemptionSheetIOS()
             return true
         }
         
         AsyncFunction("showManageSubscriptionsIOS") { () async throws -> Bool in
+            try ensureConnection()
             logDebug("showManageSubscriptionsIOS called")
             let _ = try await OpenIapModule.shared.showManageSubscriptionsIOS()
             return true
@@ -315,11 +327,13 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("beginRefundRequestIOS") { (sku: String) async throws -> String? in
+            try ensureConnection()
             logDebug("beginRefundRequestIOS called for sku: \(sku)")
             return try await OpenIapModule.shared.beginRefundRequestIOS(sku: sku)
         }
         
         AsyncFunction("getPromotedProductIOS") { () async throws -> [String: Any?]? in
+            try ensureConnection()
             logDebug("getPromotedProductIOS called")
             
             if let promoted = try await OpenIapModule.shared.getPromotedProductIOS() {
@@ -332,11 +346,13 @@ public class ExpoIapModule: Module {
             return nil
         }
         AsyncFunction("getStorefrontIOS") { () async throws -> String in
+            try ensureConnection()
             logDebug("getStorefrontIOS called")
             return try await OpenIapModule.shared.getStorefrontIOS()
         }
         
         AsyncFunction("syncIOS") { () async throws -> Bool in
+            try ensureConnection()
             logDebug("syncIOS called")
             return try await OpenIapModule.shared.syncIOS()
         }
@@ -344,21 +360,25 @@ public class ExpoIapModule: Module {
         // MARK: - Additional iOS Methods
         
         AsyncFunction("isTransactionVerifiedIOS") { (sku: String) async throws -> Bool in
+            try ensureConnection()
             logDebug("isTransactionVerifiedIOS called for sku: \(sku)")
             return await OpenIapModule.shared.isTransactionVerifiedIOS(sku: sku)
         }
         
         AsyncFunction("getTransactionJwsIOS") { (sku: String) async throws -> String? in
+            try ensureConnection()
             logDebug("getTransactionJwsIOS called for sku: \(sku)")
             return try await OpenIapModule.shared.getTransactionJwsIOS(sku: sku)
         }
         
         AsyncFunction("isEligibleForIntroOfferIOS") { (groupID: String) async throws -> Bool in
+            try ensureConnection()
             logDebug("isEligibleForIntroOfferIOS called for groupID: \(groupID)")
             return await OpenIapModule.shared.isEligibleForIntroOfferIOS(groupID: groupID)
         }
         
         AsyncFunction("subscriptionStatusIOS") { (sku: String) async throws -> [[String: Any?]]? in
+            try ensureConnection()
             logDebug("subscriptionStatusIOS called for sku: \(sku)")
             
             if let statuses = try await OpenIapModule.shared.subscriptionStatusIOS(sku: sku) {
@@ -402,6 +422,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("currentEntitlementIOS") { (sku: String) async throws -> [String: Any?]? in
+            try ensureConnection()
             logDebug("currentEntitlementIOS called for sku: \(sku)")
             do {
                 if let entitlement = try await OpenIapModule.shared.currentEntitlementIOS(sku: sku) {
@@ -414,6 +435,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("latestTransactionIOS") { (sku: String) async throws -> [String: Any?]? in
+            try ensureConnection()
             logDebug("latestTransactionIOS called for sku: \(sku)")
             do {
                 if let transaction = try await OpenIapModule.shared.latestTransactionIOS(sku: sku) {

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -85,7 +85,7 @@ public class ExpoIapModule: Module {
         // MARK: - Product Management
         
         AsyncFunction("fetchProducts") { (params: [String: Any]) async throws -> [[String: Any?]] in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("fetchProducts raw params: \(params)")
             
             // Handle both object format {skus: [...], type: "..."} and array format
@@ -154,7 +154,7 @@ public class ExpoIapModule: Module {
             guard let sku = params["sku"] as? String, !sku.isEmpty else {
                 throw OpenIapError.make(code: OpenIapError.E_PURCHASE_ERROR, message: "Missing required 'sku'")
             }
-            try ensureConnection()
+            try await ensureConnection()
 
             // Optional fields
             let andFinish = (params["andDangerouslyFinishTransactionAutomatically"] as? Bool) ?? false
@@ -212,7 +212,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("finishTransaction") { (transactionId: String) async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("finishTransaction called with id: \(transactionId)")
             let result = try await OpenIapModule.shared.finishTransaction(transactionIdentifier: transactionId)
             return result
@@ -221,7 +221,7 @@ public class ExpoIapModule: Module {
         // MARK: - Purchase History
         
         AsyncFunction("getAvailablePurchases") { (options: [String: Any?]?) async throws -> [[String: Any?]] in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getAvailablePurchases called")
             
             // Build options and get purchases directly from OpenIapModule
@@ -237,7 +237,7 @@ public class ExpoIapModule: Module {
         
         // Legacy function for backward compatibility
         AsyncFunction("getAvailableItems") { (alsoPublishToEventListener: Bool, onlyIncludeActiveItems: Bool) async throws -> [[String: Any?]] in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getAvailableItems called (legacy)")
             
             let purchaseOptions = OpenIapGetAvailablePurchasesProps(
@@ -249,7 +249,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("getPendingTransactionsIOS") { () async throws -> [[String: Any?]] in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getPendingTransactionsIOS called")
             
             let pendingTransactions = try await OpenIapModule.shared.getPendingTransactionsIOS()
@@ -257,7 +257,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("clearTransactionIOS") { () async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("clearTransactionIOS called")
             try await OpenIapModule.shared.clearTransactionIOS()
             return true
@@ -266,20 +266,20 @@ public class ExpoIapModule: Module {
         // MARK: - Receipt & Validation
         
         AsyncFunction("getReceiptIOS") { () async throws -> String in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getReceiptIOS called")
             return try await OpenIapModule.shared.getReceiptDataIOS() ?? ""
         }
         
         AsyncFunction("requestReceiptRefreshIOS") { () async throws -> String in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("requestReceiptRefreshIOS called")
             // Receipt refresh is handled automatically by StoreKit 2
             return try await OpenIapModule.shared.getReceiptDataIOS() ?? ""
         }
         
         AsyncFunction("validateReceiptIOS") { (sku: String) async throws -> [String: Any?] in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("validateReceiptIOS called for sku: \(sku)")
             do {
                 // Use OpenIapReceiptValidationProps to keep naming parity with OpenIAP
@@ -301,14 +301,14 @@ public class ExpoIapModule: Module {
         // MARK: - iOS Specific Features
         
         AsyncFunction("presentCodeRedemptionSheetIOS") { () async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("presentCodeRedemptionSheetIOS called")
             let _ = try await OpenIapModule.shared.presentCodeRedemptionSheetIOS()
             return true
         }
         
         AsyncFunction("showManageSubscriptionsIOS") { () async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("showManageSubscriptionsIOS called")
             let _ = try await OpenIapModule.shared.showManageSubscriptionsIOS()
             return true
@@ -327,13 +327,13 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("beginRefundRequestIOS") { (sku: String) async throws -> String? in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("beginRefundRequestIOS called for sku: \(sku)")
             return try await OpenIapModule.shared.beginRefundRequestIOS(sku: sku)
         }
         
         AsyncFunction("getPromotedProductIOS") { () async throws -> [String: Any?]? in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getPromotedProductIOS called")
             
             if let promoted = try await OpenIapModule.shared.getPromotedProductIOS() {
@@ -346,13 +346,13 @@ public class ExpoIapModule: Module {
             return nil
         }
         AsyncFunction("getStorefrontIOS") { () async throws -> String in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getStorefrontIOS called")
             return try await OpenIapModule.shared.getStorefrontIOS()
         }
         
         AsyncFunction("syncIOS") { () async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("syncIOS called")
             return try await OpenIapModule.shared.syncIOS()
         }
@@ -360,25 +360,25 @@ public class ExpoIapModule: Module {
         // MARK: - Additional iOS Methods
         
         AsyncFunction("isTransactionVerifiedIOS") { (sku: String) async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("isTransactionVerifiedIOS called for sku: \(sku)")
             return await OpenIapModule.shared.isTransactionVerifiedIOS(sku: sku)
         }
         
         AsyncFunction("getTransactionJwsIOS") { (sku: String) async throws -> String? in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("getTransactionJwsIOS called for sku: \(sku)")
             return try await OpenIapModule.shared.getTransactionJwsIOS(sku: sku)
         }
         
         AsyncFunction("isEligibleForIntroOfferIOS") { (groupID: String) async throws -> Bool in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("isEligibleForIntroOfferIOS called for groupID: \(groupID)")
             return await OpenIapModule.shared.isEligibleForIntroOfferIOS(groupID: groupID)
         }
         
         AsyncFunction("subscriptionStatusIOS") { (sku: String) async throws -> [[String: Any?]]? in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("subscriptionStatusIOS called for sku: \(sku)")
             
             if let statuses = try await OpenIapModule.shared.subscriptionStatusIOS(sku: sku) {
@@ -390,26 +390,9 @@ public class ExpoIapModule: Module {
                     ]
 
                     if let info = status.renewalInfo {
-                        // Convert autoRenewStatus to a proper boolean for willAutoRenew
-                        let willAutoRenew: Bool = {
-                            // Handle both Bool and string-like values without redundant casting warnings
-                            if let value = info.autoRenewStatus as? Bool { return value }
-                            let normalized = String(describing: info.autoRenewStatus).lowercased()
-                            let truthy = Set([
-                                "willrenew",
-                                "will_autorenew",
-                                "will-auto-renew",
-                                "auto_renew_on",
-                                "true",
-                                "1",
-                                "on",
-                                "yes",
-                            ])
-                            return truthy.contains(normalized)
-                        }()
-
+                        // autoRenewStatus is a Bool from OpenIAP types
                         let renewalInfo: [String: Any?] = [
-                            "willAutoRenew": willAutoRenew,
+                            "willAutoRenew": info.autoRenewStatus,
                             "autoRenewPreference": info.autoRenewPreference
                         ]
                         dict["renewalInfo"] = renewalInfo
@@ -422,7 +405,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("currentEntitlementIOS") { (sku: String) async throws -> [String: Any?]? in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("currentEntitlementIOS called for sku: \(sku)")
             do {
                 if let entitlement = try await OpenIapModule.shared.currentEntitlementIOS(sku: sku) {
@@ -435,7 +418,7 @@ public class ExpoIapModule: Module {
         }
         
         AsyncFunction("latestTransactionIOS") { (sku: String) async throws -> [String: Any?]? in
-            try ensureConnection()
+            try await ensureConnection()
             logDebug("latestTransactionIOS called for sku: \(sku)")
             do {
                 if let transaction = try await OpenIapModule.shared.latestTransactionIOS(sku: sku) {

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -22,6 +22,8 @@ struct OpenIapEvent {
 @available(iOS 15.0, tvOS 15.0, *)
 @MainActor
 public class ExpoIapModule: Module {
+    // Connection state for local validation parity with RN module
+    private var isInitialized: Bool = false
     // Subscriptions for OpenIapModule event listeners
     private var purchaseUpdatedSub: Subscription?
     private var purchaseErrorSub: Subscription?
@@ -65,6 +67,8 @@ public class ExpoIapModule: Module {
         AsyncFunction("initConnection") { () async throws -> Bool in
             logDebug("initConnection called")
             let isConnected = try await OpenIapModule.shared.initConnection()
+            // Track initialization locally for ensureConnection()
+            await MainActor.run { self.isInitialized = isConnected }
             logDebug("Connection initialized: \(isConnected)")
             return isConnected
         }
@@ -74,6 +78,7 @@ public class ExpoIapModule: Module {
             let _ = try await OpenIapModule.shared.endConnection()
             
             logDebug("Connection ended")
+            await MainActor.run { self.isInitialized = false }
             return true
         }
         
@@ -367,9 +372,8 @@ public class ExpoIapModule: Module {
                     if let info = status.renewalInfo {
                         // Convert autoRenewStatus to a proper boolean for willAutoRenew
                         let willAutoRenew: Bool = {
-                            // Try boolean first
-                            if let b = info.autoRenewStatus as? Bool { return b }
-                            // Fallback to string normalization
+                            // Handle both Bool and string-like values without redundant casting warnings
+                            if let value = info.autoRenewStatus as? Bool { return value }
                             let normalized = String(describing: info.autoRenewStatus).lowercased()
                             let truthy = Set([
                                 "willrenew",
@@ -468,4 +472,15 @@ public class ExpoIapModule: Module {
         _ = try? await OpenIapModule.shared.endConnection()
     }
     
+    // MARK: - Private Helper Methods
+    
+    private func ensureConnection() throws {
+        guard isInitialized else {
+            throw OpenIapError.make(
+                code: OpenIapError.E_INIT_CONNECTION,
+                message: "Connection not initialized. Call initConnection() first."
+            )
+        }
+    }
+
 }


### PR DESCRIPTION
Remove ensureConnection usage on Android in favor of BillingClient auto service reconnection. Replace with getBillingClientOrReject that rejects with E_INIT_CONNECTION when not initialized. Keeps behavior predictable and removes redundant connection wrapper.

Add ensureConnection helper on iOS and track local isInitialized via initConnection/endConnection. Fix main-actor mutation for state updates and clean up a warning in autoRenewStatus handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of in-app purchase connection handling and storefront retrieval on Android and iOS.
  - Clearer, consistent error reporting (e.g., when not initialized or SKU list is empty).
  - More robust purchase flow, acknowledgment, and consumption on Android.
  - Preserves and returns richer, structured product details and purchase fields.

- Refactor
  - Unified connection checks across platforms; batched product queries on Android for efficiency.
  - Internal helpers streamlined; no changes to public API or behavior for existing methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->