### PR TITLE
Sync Expo IAP types with RN IAP

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -554,14 +554,14 @@ Examples:
 // Preferred (object style)
 throw new PurchaseError({
   message: 'No SKUs provided',
-  code: ErrorCode.E_EMPTY_SKU_LIST,
+  code: ErrorCode.EmptySkuList,
 });
 
 // Also valid for richer context
 return Promise.reject(
   new PurchaseError({
     message: 'Purchase token is required to finish transaction',
-    code: ErrorCode.E_DEVELOPER_ERROR,
+    code: ErrorCode.DeveloperError,
     productId: sku,
     platform: 'android',
   }),

--- a/docs/blog/2025-08-18-v2.8.0-migration-guide.md
+++ b/docs/blog/2025-08-18-v2.8.0-migration-guide.md
@@ -28,7 +28,7 @@ import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
 
 ### Product Types
 
-**ProductIOS & SubscriptionProductIOS:**
+**ProductIOS & ProductSubscriptionIOS:**
 
 - `displayName` - Product display name
 - `isFamilyShareable` - Family sharing availability
@@ -111,7 +111,7 @@ import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
 
 ### Product Types
 
-**ProductAndroid & SubscriptionProductAndroid:**
+**ProductAndroid & ProductSubscriptionAndroid:**
 
 - `name` - Product display name
 - `oneTimePurchaseOfferDetails` - One-time purchase offer details
@@ -177,7 +177,7 @@ Type names have also been updated to use uppercase `IOS`:
 import {
   ProductIOS,
   ProductPurchaseIos,
-  SubscriptionProductIOS,
+  ProductSubscriptionIOS,
   ProductStatusIos,
 } from 'expo-iap';
 
@@ -185,7 +185,7 @@ import {
 import {
   ProductIOS,
   ProductPurchaseIOS,
-  SubscriptionProductIOS,
+  ProductSubscriptionIOS,
   ProductStatusIOS,
 } from 'expo-iap';
 ```

--- a/docs/blog/2025-09-12-v2.9.7.md
+++ b/docs/blog/2025-09-12-v2.9.7.md
@@ -28,14 +28,14 @@ Example flow:
 import {
   fetchProducts,
   requestPurchase,
-  type SubscriptionProduct,
+  type ProductSubscription,
 } from 'expo-iap';
 
 // 1) Fetch your subscription product(s)
 const products = await fetchProducts({skus: ['premium_monthly'], type: 'subs'});
 const sub = products.find(
   (p) => p.id === 'premium_monthly',
-) as SubscriptionProduct;
+) as ProductSubscription;
 
 // 2) Build subscriptionOffers from the fetched product details
 const subscriptionOffers = (sub.subscriptionOfferDetailsAndroid ?? []).map(

--- a/docs/blog/2025-09-13-v3.0.0.md
+++ b/docs/blog/2025-09-13-v3.0.0.md
@@ -52,14 +52,14 @@ import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
 ### Fetch products (in‑app or subs)
 
 ```ts
-import {fetchProducts, type SubscriptionProduct} from 'expo-iap';
+import {fetchProducts, type ProductSubscription} from 'expo-iap';
 
 const inapps = await fetchProducts({skus: ['prod1', 'prod2'], type: 'inapp'});
 
 const subs = (await fetchProducts({
   skus: ['sub_monthly'],
   type: 'subs',
-})) as SubscriptionProduct[];
+})) as ProductSubscription[];
 ```
 
 ### Request purchase (products or subs)

--- a/docs/docs/api/error-codes.md
+++ b/docs/docs/api/error-codes.md
@@ -153,7 +153,7 @@ const error = PurchaseError.fromPlatformError(
   {code: 2, message: 'User cancelled'},
   'ios',
 );
-console.log(error.code); // ErrorCode.E_USER_CANCELLED
+console.log(error.code); // ErrorCode.UserCancelled
 ```
 
 ### Instance Methods
@@ -174,7 +174,7 @@ const error = new PurchaseError(
   'User cancelled',
   undefined,
   undefined,
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'com.app.premium',
   'ios',
 );
@@ -198,7 +198,7 @@ ErrorCodeUtils.getNativeErrorCode(errorCode: ErrorCode): string
 
 ```tsx
 const nativeCode = ErrorCodeUtils.getNativeErrorCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
 );
 console.log(nativeCode); // Platform-specific code
 ```
@@ -219,14 +219,14 @@ ErrorCodeUtils.fromPlatformCode(
 ```tsx
 // iOS
 const errorCode = ErrorCodeUtils.fromPlatformCode(2, 'ios');
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 
 // Android
 const errorCode = ErrorCodeUtils.fromPlatformCode(
   'E_USER_CANCELLED',
   'android',
 );
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 ```
 
 ### toPlatformCode
@@ -245,14 +245,14 @@ ErrorCodeUtils.toPlatformCode(
 ```tsx
 // iOS
 const iosCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(iosCode); // 2
 
 // Android
 const androidCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'android',
 );
 console.log(androidCode); // 'E_USER_CANCELLED'
@@ -273,7 +273,7 @@ ErrorCodeUtils.isValidForPlatform(
 
 ```tsx
 const isValid = ErrorCodeUtils.isValidForPlatform(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(isValid); // true
@@ -318,13 +318,13 @@ const {requestPurchase} = useIAP({
     });
 
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your internet connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert('Item Unavailable', 'This item is not available');
         break;
       default:
@@ -352,9 +352,9 @@ const handlePurchaseWithRetry = async (productId: string, retryCount = 0) => {
 
     // Determine if we should retry
     const retryableErrors = [
-      ErrorCode.E_NETWORK_ERROR,
-      ErrorCode.E_SERVICE_ERROR,
-      ErrorCode.E_INTERRUPTED,
+      ErrorCode.NetworkError,
+      ErrorCode.ServiceError,
+      ErrorCode.Interrupted,
     ];
 
     const shouldRetry =

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -160,10 +160,10 @@ export type ChangeEventPayload = {value: string};
 
 // iOS detailed product types
 export enum ProductTypeIOS {
-  consumable = 'consumable',
-  nonConsumable = 'nonConsumable',
-  autoRenewableSubscription = 'autoRenewableSubscription',
-  nonRenewingSubscription = 'nonRenewingSubscription',
+  Consumable = 'consumable',
+  NonConsumable = 'nonConsumable',
+  AutoRenewableSubscription = 'autoRenewableSubscription',
+  NonRenewingSubscription = 'nonRenewingSubscription',
 }
 
 // Shared product information
@@ -181,12 +181,12 @@ export type ProductCommon = {
 };
 
 export enum PurchaseState {
-  pending = 'pending',
-  purchased = 'purchased',
-  failed = 'failed',
-  restored = 'restored', // iOS only
-  deferred = 'deferred', // iOS only
-  unknown = 'unknown',
+  Pending = 'pending',
+  Purchased = 'purchased',
+  Failed = 'failed',
+  Restored = 'restored', // iOS only
+  Deferred = 'deferred', // iOS only
+  Unknown = 'unknown',
 }
 
 // Shared purchase information
@@ -385,7 +385,7 @@ export type Product =
   | (ProductAndroid & AndroidPlatform)
   | (ProductIOS & IosPlatform);
 
-export type SubscriptionProduct =
+export type ProductSubscription =
   | (ProductSubscriptionAndroid & AndroidPlatform)
   | (ProductSubscriptionIOS & IosPlatform);
 
@@ -528,7 +528,7 @@ export interface FinishTransactionParams {
 ```ts
 export interface IapContext {
   products: Product[];
-  subscriptions: SubscriptionProduct[];
+  subscriptions: ProductSubscription[];
   availablePurchases: Purchase[];
   promotedProduct?: Product;
   currentPurchase?: Purchase;
@@ -541,7 +541,7 @@ export interface IapContext {
   fetchProducts(params: {
     skus: string[];
     type?: 'inapp' | 'subs' | 'all';
-  }): Promise<Product[] | SubscriptionProduct[]>;
+  }): Promise<Product[] | ProductSubscription[]>;
 
   requestPurchase(params: {
     request: RequestPurchaseProps | RequestSubscriptionProps;

--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -97,7 +97,7 @@ interface UseIAPOptions {
 
   ```tsx
   onPurchaseError: (error) => {
-    if (error.code !== ErrorCode.E_USER_CANCELLED) {
+    if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
   };
@@ -150,7 +150,7 @@ interface UseIAPOptions {
 
 #### subscriptions
 
-- **Type**: `SubscriptionProduct[]`
+- **Type**: `ProductSubscription[]`
 - **Description**: Array of available subscription products
 - **Example**:
 
@@ -485,13 +485,13 @@ const {requestPurchase} = useIAP({
   onPurchaseError: (error) => {
     // Error is automatically typed as PurchaseError
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert(
           'Item Unavailable',
           'This item is not available for purchase',
@@ -544,7 +544,7 @@ const {requestPurchase} = useIAP({
      console.error('IAP Error:', error);
 
      // Show user-friendly message
-     if (error.code !== ErrorCode.E_USER_CANCELLED) {
+     if (error.code !== ErrorCode.UserCancelled) {
        Alert.alert('Purchase Failed', error.message);
      }
    };

--- a/docs/docs/getting-started/setup-android.md
+++ b/docs/docs/getting-started/setup-android.md
@@ -116,7 +116,7 @@ const AndroidProductItem = ({product}: {product: Product}) => {
 const AndroidSubscriptionItem = ({
   subscription,
 }: {
-  subscription: SubscriptionProduct;
+  subscription: ProductSubscription;
 }) => {
   const {requestPurchase} = useIAP();
 
@@ -164,19 +164,19 @@ const AndroidSubscriptionItem = ({
 ```tsx
 const handleAndroidError = (error: PurchaseError) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - no action needed
       break;
-    case ErrorCode.E_ITEM_UNAVAILABLE:
+    case ErrorCode.ItemUnavailable:
       Alert.alert(
         'Product Unavailable',
         'This item is not available for purchase',
       );
       break;
-    case ErrorCode.E_SERVICE_ERROR:
+    case ErrorCode.ServiceError:
       Alert.alert('Service Error', 'Google Play services are unavailable');
       break;
-    case ErrorCode.E_DEVELOPER_ERROR:
+    case ErrorCode.DeveloperError:
       Alert.alert('Configuration Error', 'Please contact support');
       break;
     default:

--- a/docs/docs/getting-started/setup-ios.md
+++ b/docs/docs/getting-started/setup-ios.md
@@ -116,7 +116,7 @@ const validateReceipt = async (productId: string) => {
 ```tsx
 const handlePurchaseError = (error: any) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - don't show error
       break;
     case ErrorCode.E_PAYMENT_NOT_ALLOWED:

--- a/docs/versioned_docs/version-2.6/api/error-codes.md
+++ b/docs/versioned_docs/version-2.6/api/error-codes.md
@@ -153,7 +153,7 @@ const error = PurchaseError.fromPlatformError(
   {code: 2, message: 'User cancelled'},
   'ios',
 );
-console.log(error.code); // ErrorCode.E_USER_CANCELLED
+console.log(error.code); // ErrorCode.UserCancelled
 ```
 
 ### Instance Methods
@@ -174,7 +174,7 @@ const error = new PurchaseError(
   'User cancelled',
   undefined,
   undefined,
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'com.app.premium',
   'ios',
 );
@@ -198,7 +198,7 @@ ErrorCodeUtils.getNativeErrorCode(errorCode: ErrorCode): string
 
 ```tsx
 const nativeCode = ErrorCodeUtils.getNativeErrorCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
 );
 console.log(nativeCode); // Platform-specific code
 ```
@@ -219,14 +219,14 @@ ErrorCodeUtils.fromPlatformCode(
 ```tsx
 // iOS
 const errorCode = ErrorCodeUtils.fromPlatformCode(2, 'ios');
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 
 // Android
 const errorCode = ErrorCodeUtils.fromPlatformCode(
   'E_USER_CANCELLED',
   'android',
 );
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 ```
 
 ### toPlatformCode
@@ -245,14 +245,14 @@ ErrorCodeUtils.toPlatformCode(
 ```tsx
 // iOS
 const iosCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(iosCode); // 2
 
 // Android
 const androidCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'android',
 );
 console.log(androidCode); // 'E_USER_CANCELLED'
@@ -273,7 +273,7 @@ ErrorCodeUtils.isValidForPlatform(
 
 ```tsx
 const isValid = ErrorCodeUtils.isValidForPlatform(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(isValid); // true
@@ -318,13 +318,13 @@ const {requestPurchase} = useIAP({
     });
 
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your internet connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert('Item Unavailable', 'This item is not available');
         break;
       default:
@@ -347,9 +347,9 @@ const handlePurchaseWithRetry = async (productId: string, retryCount = 0) => {
 
     // Determine if we should retry
     const retryableErrors = [
-      ErrorCode.E_NETWORK_ERROR,
-      ErrorCode.E_SERVICE_ERROR,
-      ErrorCode.E_INTERRUPTED,
+      ErrorCode.NetworkError,
+      ErrorCode.ServiceError,
+      ErrorCode.Interrupted,
     ];
 
     const shouldRetry =

--- a/docs/versioned_docs/version-2.6/api/methods/core-methods.md
+++ b/docs/versioned_docs/version-2.6/api/methods/core-methods.md
@@ -228,7 +228,7 @@ const fetchSubscriptions = async () => {
 
 - `skus` (string[]): Array of subscription IDs to fetch
 
-**Returns:** `Promise<SubscriptionProduct[]>`
+**Returns:** `Promise<ProductSubscription[]>`
 
 ## requestPurchase()
 

--- a/docs/versioned_docs/version-2.6/api/use-iap.md
+++ b/docs/versioned_docs/version-2.6/api/use-iap.md
@@ -86,7 +86,7 @@ interface UseIAPOptions {
 
   ```tsx
   onPurchaseError: (error) => {
-    if (error.code !== ErrorCode.E_USER_CANCELLED) {
+    if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
   };
@@ -139,7 +139,7 @@ interface UseIAPOptions {
 
 #### subscriptions
 
-- **Type**: `SubscriptionProduct[]`
+- **Type**: `ProductSubscription[]`
 - **Description**: Array of available subscription products
 - **Example**:
 
@@ -228,7 +228,7 @@ interface UseIAPOptions {
 
 #### getSubscriptions
 
-- **Type**: `(subscriptionIds: string[]) => Promise<SubscriptionProduct[]>`
+- **Type**: `(subscriptionIds: string[]) => Promise<ProductSubscription[]>`
 - **Description**: Fetch subscription products from the store
 - **Parameters**:
   - `subscriptionIds`: Array of subscription IDs to fetch
@@ -439,13 +439,13 @@ const {requestPurchase} = useIAP({
   onPurchaseError: (error) => {
     // Error is automatically typed as PurchaseError
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert(
           'Item Unavailable',
           'This item is not available for purchase',
@@ -493,7 +493,7 @@ const {requestPurchase} = useIAP({
      console.error('IAP Error:', error);
 
      // Show user-friendly message
-     if (error.code !== ErrorCode.E_USER_CANCELLED) {
+     if (error.code !== ErrorCode.UserCancelled) {
        Alert.alert('Purchase Failed', error.message);
      }
    };

--- a/docs/versioned_docs/version-2.6/examples/complete-impl.md
+++ b/docs/versioned_docs/version-2.6/examples/complete-impl.md
@@ -171,7 +171,7 @@ if (isValidReceipt) {
 
 ```tsx
 // Handle different error types appropriately
-if (currentPurchaseError.code === ErrorCode.E_USER_CANCELLED) {
+if (currentPurchaseError.code === ErrorCode.UserCancelled) {
   return; // Don't show error for user cancellation
 }
 

--- a/docs/versioned_docs/version-2.6/getting-started/setup-android.md
+++ b/docs/versioned_docs/version-2.6/getting-started/setup-android.md
@@ -188,7 +188,7 @@ const AndroidProductItem = ({product}: {product: Product}) => {
 const AndroidSubscriptionItem = ({
   subscription,
 }: {
-  subscription: SubscriptionProduct;
+  subscription: ProductSubscription;
 }) => {
   const {requestPurchase} = useIAP();
 
@@ -236,19 +236,19 @@ const AndroidSubscriptionItem = ({
 ```tsx
 const handleAndroidError = (error: PurchaseError) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - no action needed
       break;
-    case ErrorCode.E_ITEM_UNAVAILABLE:
+    case ErrorCode.ItemUnavailable:
       Alert.alert(
         'Product Unavailable',
         'This item is not available for purchase',
       );
       break;
-    case ErrorCode.E_SERVICE_ERROR:
+    case ErrorCode.ServiceError:
       Alert.alert('Service Error', 'Google Play services are unavailable');
       break;
-    case ErrorCode.E_DEVELOPER_ERROR:
+    case ErrorCode.DeveloperError:
       Alert.alert('Configuration Error', 'Please contact support');
       break;
     default:

--- a/docs/versioned_docs/version-2.6/getting-started/setup-ios.md
+++ b/docs/versioned_docs/version-2.6/getting-started/setup-ios.md
@@ -181,7 +181,7 @@ const validateReceipt = async (productId: string) => {
 ```tsx
 const handlePurchaseError = (error: any) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - don't show error
       break;
     case ErrorCode.E_PAYMENT_NOT_ALLOWED:

--- a/docs/versioned_docs/version-2.7/api/error-codes.md
+++ b/docs/versioned_docs/version-2.7/api/error-codes.md
@@ -153,7 +153,7 @@ const error = PurchaseError.fromPlatformError(
   {code: 2, message: 'User cancelled'},
   'ios',
 );
-console.log(error.code); // ErrorCode.E_USER_CANCELLED
+console.log(error.code); // ErrorCode.UserCancelled
 ```
 
 ### Instance Methods
@@ -174,7 +174,7 @@ const error = new PurchaseError(
   'User cancelled',
   undefined,
   undefined,
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'com.app.premium',
   'ios',
 );
@@ -198,7 +198,7 @@ ErrorCodeUtils.getNativeErrorCode(errorCode: ErrorCode): string
 
 ```tsx
 const nativeCode = ErrorCodeUtils.getNativeErrorCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
 );
 console.log(nativeCode); // Platform-specific code
 ```
@@ -219,14 +219,14 @@ ErrorCodeUtils.fromPlatformCode(
 ```tsx
 // iOS
 const errorCode = ErrorCodeUtils.fromPlatformCode(2, 'ios');
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 
 // Android
 const errorCode = ErrorCodeUtils.fromPlatformCode(
   'E_USER_CANCELLED',
   'android',
 );
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 ```
 
 ### toPlatformCode
@@ -245,14 +245,14 @@ ErrorCodeUtils.toPlatformCode(
 ```tsx
 // iOS
 const iosCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(iosCode); // 2
 
 // Android
 const androidCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'android',
 );
 console.log(androidCode); // 'E_USER_CANCELLED'
@@ -273,7 +273,7 @@ ErrorCodeUtils.isValidForPlatform(
 
 ```tsx
 const isValid = ErrorCodeUtils.isValidForPlatform(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(isValid); // true
@@ -318,13 +318,13 @@ const {requestPurchase} = useIAP({
     });
 
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your internet connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert('Item Unavailable', 'This item is not available');
         break;
       default:
@@ -347,9 +347,9 @@ const handlePurchaseWithRetry = async (productId: string, retryCount = 0) => {
 
     // Determine if we should retry
     const retryableErrors = [
-      ErrorCode.E_NETWORK_ERROR,
-      ErrorCode.E_SERVICE_ERROR,
-      ErrorCode.E_INTERRUPTED,
+      ErrorCode.NetworkError,
+      ErrorCode.ServiceError,
+      ErrorCode.Interrupted,
     ];
 
     const shouldRetry =

--- a/docs/versioned_docs/version-2.7/api/methods/core-methods.md
+++ b/docs/versioned_docs/version-2.7/api/methods/core-methods.md
@@ -228,7 +228,7 @@ const fetchSubscriptions = async () => {
 
 - `skus` (string[]): Array of subscription IDs to fetch
 
-**Returns:** `Promise<SubscriptionProduct[]>`
+**Returns:** `Promise<ProductSubscription[]>`
 
 ## requestPurchase()
 

--- a/docs/versioned_docs/version-2.7/api/use-iap.md
+++ b/docs/versioned_docs/version-2.7/api/use-iap.md
@@ -86,7 +86,7 @@ interface UseIAPOptions {
 
   ```tsx
   onPurchaseError: (error) => {
-    if (error.code !== ErrorCode.E_USER_CANCELLED) {
+    if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
   };
@@ -139,7 +139,7 @@ interface UseIAPOptions {
 
 #### subscriptions
 
-- **Type**: `SubscriptionProduct[]`
+- **Type**: `ProductSubscription[]`
 - **Description**: Array of available subscription products
 - **Example**:
 
@@ -228,7 +228,7 @@ interface UseIAPOptions {
 
 #### getSubscriptions
 
-- **Type**: `(subscriptionIds: string[]) => Promise<SubscriptionProduct[]>`
+- **Type**: `(subscriptionIds: string[]) => Promise<ProductSubscription[]>`
 - **Description**: Fetch subscription products from the store
 - **Parameters**:
   - `subscriptionIds`: Array of subscription IDs to fetch
@@ -439,13 +439,13 @@ const {requestPurchase} = useIAP({
   onPurchaseError: (error) => {
     // Error is automatically typed as PurchaseError
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert(
           'Item Unavailable',
           'This item is not available for purchase',
@@ -493,7 +493,7 @@ const {requestPurchase} = useIAP({
      console.error('IAP Error:', error);
 
      // Show user-friendly message
-     if (error.code !== ErrorCode.E_USER_CANCELLED) {
+     if (error.code !== ErrorCode.UserCancelled) {
        Alert.alert('Purchase Failed', error.message);
      }
    };

--- a/docs/versioned_docs/version-2.7/examples/complete-impl.md
+++ b/docs/versioned_docs/version-2.7/examples/complete-impl.md
@@ -171,7 +171,7 @@ if (isValidReceipt) {
 
 ```tsx
 // Handle different error types appropriately
-if (currentPurchaseError.code === ErrorCode.E_USER_CANCELLED) {
+if (currentPurchaseError.code === ErrorCode.UserCancelled) {
   return; // Don't show error for user cancellation
 }
 

--- a/docs/versioned_docs/version-2.7/getting-started/setup-android.md
+++ b/docs/versioned_docs/version-2.7/getting-started/setup-android.md
@@ -188,7 +188,7 @@ const AndroidProductItem = ({product}: {product: Product}) => {
 const AndroidSubscriptionItem = ({
   subscription,
 }: {
-  subscription: SubscriptionProduct;
+  subscription: ProductSubscription;
 }) => {
   const {requestPurchase} = useIAP();
 
@@ -236,19 +236,19 @@ const AndroidSubscriptionItem = ({
 ```tsx
 const handleAndroidError = (error: PurchaseError) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - no action needed
       break;
-    case ErrorCode.E_ITEM_UNAVAILABLE:
+    case ErrorCode.ItemUnavailable:
       Alert.alert(
         'Product Unavailable',
         'This item is not available for purchase',
       );
       break;
-    case ErrorCode.E_SERVICE_ERROR:
+    case ErrorCode.ServiceError:
       Alert.alert('Service Error', 'Google Play services are unavailable');
       break;
-    case ErrorCode.E_DEVELOPER_ERROR:
+    case ErrorCode.DeveloperError:
       Alert.alert('Configuration Error', 'Please contact support');
       break;
     default:

--- a/docs/versioned_docs/version-2.7/getting-started/setup-ios.md
+++ b/docs/versioned_docs/version-2.7/getting-started/setup-ios.md
@@ -183,7 +183,7 @@ const validateReceiptIOS = async (productId: string) => {
 ```tsx
 const handlePurchaseError = (error: any) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - don't show error
       break;
     case ErrorCode.E_PAYMENT_NOT_ALLOWED:

--- a/docs/versioned_docs/version-2.9/api/error-codes.md
+++ b/docs/versioned_docs/version-2.9/api/error-codes.md
@@ -153,7 +153,7 @@ const error = PurchaseError.fromPlatformError(
   {code: 2, message: 'User cancelled'},
   'ios',
 );
-console.log(error.code); // ErrorCode.E_USER_CANCELLED
+console.log(error.code); // ErrorCode.UserCancelled
 ```
 
 ### Instance Methods
@@ -174,7 +174,7 @@ const error = new PurchaseError(
   'User cancelled',
   undefined,
   undefined,
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'com.app.premium',
   'ios',
 );
@@ -198,7 +198,7 @@ ErrorCodeUtils.getNativeErrorCode(errorCode: ErrorCode): string
 
 ```tsx
 const nativeCode = ErrorCodeUtils.getNativeErrorCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
 );
 console.log(nativeCode); // Platform-specific code
 ```
@@ -219,14 +219,14 @@ ErrorCodeUtils.fromPlatformCode(
 ```tsx
 // iOS
 const errorCode = ErrorCodeUtils.fromPlatformCode(2, 'ios');
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 
 // Android
 const errorCode = ErrorCodeUtils.fromPlatformCode(
   'E_USER_CANCELLED',
   'android',
 );
-console.log(errorCode); // ErrorCode.E_USER_CANCELLED
+console.log(errorCode); // ErrorCode.UserCancelled
 ```
 
 ### toPlatformCode
@@ -245,14 +245,14 @@ ErrorCodeUtils.toPlatformCode(
 ```tsx
 // iOS
 const iosCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(iosCode); // 2
 
 // Android
 const androidCode = ErrorCodeUtils.toPlatformCode(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'android',
 );
 console.log(androidCode); // 'E_USER_CANCELLED'
@@ -273,7 +273,7 @@ ErrorCodeUtils.isValidForPlatform(
 
 ```tsx
 const isValid = ErrorCodeUtils.isValidForPlatform(
-  ErrorCode.E_USER_CANCELLED,
+  ErrorCode.UserCancelled,
   'ios',
 );
 console.log(isValid); // true
@@ -318,13 +318,13 @@ const {requestPurchase} = useIAP({
     });
 
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your internet connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert('Item Unavailable', 'This item is not available');
         break;
       default:
@@ -352,9 +352,9 @@ const handlePurchaseWithRetry = async (productId: string, retryCount = 0) => {
 
     // Determine if we should retry
     const retryableErrors = [
-      ErrorCode.E_NETWORK_ERROR,
-      ErrorCode.E_SERVICE_ERROR,
-      ErrorCode.E_INTERRUPTED,
+      ErrorCode.NetworkError,
+      ErrorCode.ServiceError,
+      ErrorCode.Interrupted,
     ];
 
     const shouldRetry =

--- a/docs/versioned_docs/version-2.9/api/methods/core-methods.md
+++ b/docs/versioned_docs/version-2.9/api/methods/core-methods.md
@@ -308,7 +308,7 @@ const subs = await fetchProducts({
 
 - `skus` (string[]): Array of subscription IDs to fetch
 
-**Returns:** `Promise<SubscriptionProduct[]>`
+**Returns:** `Promise<ProductSubscription[]>`
 
 ## requestPurchase()
 

--- a/docs/versioned_docs/version-2.9/api/use-iap.md
+++ b/docs/versioned_docs/version-2.9/api/use-iap.md
@@ -94,7 +94,7 @@ interface UseIAPOptions {
 
   ```tsx
   onPurchaseError: (error) => {
-    if (error.code !== ErrorCode.E_USER_CANCELLED) {
+    if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
   };
@@ -147,7 +147,7 @@ interface UseIAPOptions {
 
 #### subscriptions
 
-- **Type**: `SubscriptionProduct[]`
+- **Type**: `ProductSubscription[]`
 - **Description**: Array of available subscription products
 - **Example**:
 
@@ -530,13 +530,13 @@ const {requestPurchase} = useIAP({
   onPurchaseError: (error) => {
     // Error is automatically typed as PurchaseError
     switch (error.code) {
-      case ErrorCode.E_USER_CANCELLED:
+      case ErrorCode.UserCancelled:
         // Don't show error for user cancellation
         break;
-      case ErrorCode.E_NETWORK_ERROR:
+      case ErrorCode.NetworkError:
         Alert.alert('Network Error', 'Please check your connection');
         break;
-      case ErrorCode.E_ITEM_UNAVAILABLE:
+      case ErrorCode.ItemUnavailable:
         Alert.alert(
           'Item Unavailable',
           'This item is not available for purchase',
@@ -589,7 +589,7 @@ const {requestPurchase} = useIAP({
      console.error('IAP Error:', error);
 
      // Show user-friendly message
-     if (error.code !== ErrorCode.E_USER_CANCELLED) {
+     if (error.code !== ErrorCode.UserCancelled) {
        Alert.alert('Purchase Failed', error.message);
      }
    };

--- a/docs/versioned_docs/version-2.9/examples/complete-impl.md
+++ b/docs/versioned_docs/version-2.9/examples/complete-impl.md
@@ -172,7 +172,7 @@ if (isValidReceipt) {
 
 ```tsx
 // Handle different error types appropriately
-if (currentPurchaseError.code === ErrorCode.E_USER_CANCELLED) {
+if (currentPurchaseError.code === ErrorCode.UserCancelled) {
   return; // Don't show error for user cancellation
 }
 

--- a/docs/versioned_docs/version-2.9/getting-started/setup-android.md
+++ b/docs/versioned_docs/version-2.9/getting-started/setup-android.md
@@ -116,7 +116,7 @@ const AndroidProductItem = ({product}: {product: Product}) => {
 const AndroidSubscriptionItem = ({
   subscription,
 }: {
-  subscription: SubscriptionProduct;
+  subscription: ProductSubscription;
 }) => {
   const {requestPurchase} = useIAP();
 
@@ -164,19 +164,19 @@ const AndroidSubscriptionItem = ({
 ```tsx
 const handleAndroidError = (error: PurchaseError) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - no action needed
       break;
-    case ErrorCode.E_ITEM_UNAVAILABLE:
+    case ErrorCode.ItemUnavailable:
       Alert.alert(
         'Product Unavailable',
         'This item is not available for purchase',
       );
       break;
-    case ErrorCode.E_SERVICE_ERROR:
+    case ErrorCode.ServiceError:
       Alert.alert('Service Error', 'Google Play services are unavailable');
       break;
-    case ErrorCode.E_DEVELOPER_ERROR:
+    case ErrorCode.DeveloperError:
       Alert.alert('Configuration Error', 'Please contact support');
       break;
     default:

--- a/docs/versioned_docs/version-2.9/getting-started/setup-ios.md
+++ b/docs/versioned_docs/version-2.9/getting-started/setup-ios.md
@@ -116,7 +116,7 @@ const validateReceipt = async (productId: string) => {
 ```tsx
 const handlePurchaseError = (error: any) => {
   switch (error.code) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       // User cancelled - don't show error
       break;
     case ErrorCode.E_PAYMENT_NOT_ALLOWED:

--- a/example/app/subscription-flow.tsx
+++ b/example/app/subscription-flow.tsx
@@ -15,7 +15,7 @@ import {requestPurchase, useIAP, showManageSubscriptionsIOS} from '../../src';
 import Loading from '../src/components/Loading';
 import {SUBSCRIPTION_PRODUCT_IDS} from '../../src/utils/constants';
 import type {
-  SubscriptionProduct,
+  ProductSubscription,
   PurchaseError,
   PurchaseIOS,
   Purchase,
@@ -65,7 +65,7 @@ export default function SubscriptionFlow() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [isCheckingStatus, setIsCheckingStatus] = useState(false);
   const [selectedSubscription, setSelectedSubscription] =
-    useState<SubscriptionProduct | null>(null);
+    useState<ProductSubscription | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [isHandlingPurchase, setIsHandlingPurchase] = useState(false);
   const [lastPurchase, setLastPurchase] = useState<Purchase | null>(null);
@@ -423,7 +423,7 @@ export default function SubscriptionFlow() {
   };
 
   const getSubscriptionDisplayPrice = (
-    subscription: SubscriptionProduct,
+    subscription: ProductSubscription,
   ): string => {
     if (
       'subscriptionOfferDetailsAndroid' in subscription &&
@@ -469,7 +469,7 @@ export default function SubscriptionFlow() {
   };
 
   const getIntroductoryOffer = (
-    subscription: SubscriptionProduct,
+    subscription: ProductSubscription,
   ): string | null => {
     if (
       'subscriptionInfoIOS' in subscription &&
@@ -496,7 +496,7 @@ export default function SubscriptionFlow() {
     return null;
   };
 
-  const getSubscriptionPeriod = (subscription: SubscriptionProduct): string => {
+  const getSubscriptionPeriod = (subscription: ProductSubscription): string => {
     if (
       'subscriptionOfferDetailsAndroid' in subscription &&
       subscription.subscriptionOfferDetailsAndroid
@@ -520,7 +520,7 @@ export default function SubscriptionFlow() {
     return 'Unknown';
   };
 
-  const handleSubscriptionPress = (subscription: SubscriptionProduct) => {
+  const handleSubscriptionPress = (subscription: ProductSubscription) => {
     setSelectedSubscription(subscription);
     setModalVisible(true);
   };

--- a/src/ExpoIap.types.ts
+++ b/src/ExpoIap.types.ts
@@ -16,6 +16,15 @@ export type ChangeEventPayload = {
 
 export type ProductType = 'inapp' | 'subs';
 
+export enum PurchaseState {
+  Pending = 'pending',
+  Purchased = 'purchased',
+  Failed = 'failed',
+  Restored = 'restored',
+  Deferred = 'deferred',
+  Unknown = 'unknown',
+}
+
 // =============================================================================
 // COMMON TYPES (Base types shared across all platforms)
 // =============================================================================
@@ -37,9 +46,13 @@ export type PurchaseCommon = {
   id: string; // Transaction identifier - used by finishTransaction
   productId: string; // Product identifier - which product was purchased
   ids?: string[]; // Product identifiers for purchases that include multiple products
+  transactionId?: string; // Legacy identifier
   transactionDate: number;
   purchaseToken?: string; // Unified token (iOS: JWS, Android: purchaseToken)
   platform?: string;
+  quantity: number;
+  purchaseState: PurchaseState;
+  isAutoRenewing: boolean;
 };
 
 export type ProductSubscriptionCommon = ProductCommon & {
@@ -55,7 +68,7 @@ export type Product =
   | (ProductAndroid & AndroidPlatform)
   | (ProductIOS & IosPlatform);
 
-export type SubscriptionProduct =
+export type ProductSubscription =
   | (ProductSubscriptionAndroid & AndroidPlatform)
   | (ProductSubscriptionIOS & IosPlatform);
 
@@ -80,41 +93,41 @@ export type PurchaseResult = {
  * These are mapped to platform-specific error codes and provide consistent error handling
  */
 export enum ErrorCode {
-  E_UNKNOWN = 'E_UNKNOWN',
-  E_USER_CANCELLED = 'E_USER_CANCELLED',
-  E_USER_ERROR = 'E_USER_ERROR',
-  E_ITEM_UNAVAILABLE = 'E_ITEM_UNAVAILABLE',
-  E_REMOTE_ERROR = 'E_REMOTE_ERROR',
-  E_NETWORK_ERROR = 'E_NETWORK_ERROR',
-  E_SERVICE_ERROR = 'E_SERVICE_ERROR',
-  E_RECEIPT_FAILED = 'E_RECEIPT_FAILED',
-  E_RECEIPT_FINISHED = 'E_RECEIPT_FINISHED',
-  E_RECEIPT_FINISHED_FAILED = 'E_RECEIPT_FINISHED_FAILED',
-  E_NOT_PREPARED = 'E_NOT_PREPARED',
-  E_NOT_ENDED = 'E_NOT_ENDED',
-  E_ALREADY_OWNED = 'E_ALREADY_OWNED',
-  E_DEVELOPER_ERROR = 'E_DEVELOPER_ERROR',
-  E_BILLING_RESPONSE_JSON_PARSE_ERROR = 'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
-  E_DEFERRED_PAYMENT = 'E_DEFERRED_PAYMENT',
-  E_INTERRUPTED = 'E_INTERRUPTED',
-  E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
-  E_PURCHASE_ERROR = 'E_PURCHASE_ERROR',
-  E_SYNC_ERROR = 'E_SYNC_ERROR',
-  E_TRANSACTION_VALIDATION_FAILED = 'E_TRANSACTION_VALIDATION_FAILED',
-  E_ACTIVITY_UNAVAILABLE = 'E_ACTIVITY_UNAVAILABLE',
-  E_ALREADY_PREPARED = 'E_ALREADY_PREPARED',
-  E_PENDING = 'E_PENDING',
-  E_CONNECTION_CLOSED = 'E_CONNECTION_CLOSED',
+  Unknown = 'E_UNKNOWN',
+  UserCancelled = 'E_USER_CANCELLED',
+  UserError = 'E_USER_ERROR',
+  ItemUnavailable = 'E_ITEM_UNAVAILABLE',
+  RemoteError = 'E_REMOTE_ERROR',
+  NetworkError = 'E_NETWORK_ERROR',
+  ServiceError = 'E_SERVICE_ERROR',
+  ReceiptFailed = 'E_RECEIPT_FAILED',
+  ReceiptFinished = 'E_RECEIPT_FINISHED',
+  ReceiptFinishedFailed = 'E_RECEIPT_FINISHED_FAILED',
+  NotPrepared = 'E_NOT_PREPARED',
+  NotEnded = 'E_NOT_ENDED',
+  AlreadyOwned = 'E_ALREADY_OWNED',
+  DeveloperError = 'E_DEVELOPER_ERROR',
+  BillingResponseJsonParseError = 'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
+  DeferredPayment = 'E_DEFERRED_PAYMENT',
+  Interrupted = 'E_INTERRUPTED',
+  IapNotAvailable = 'E_IAP_NOT_AVAILABLE',
+  PurchaseError = 'E_PURCHASE_ERROR',
+  SyncError = 'E_SYNC_ERROR',
+  TransactionValidationFailed = 'E_TRANSACTION_VALIDATION_FAILED',
+  ActivityUnavailable = 'E_ACTIVITY_UNAVAILABLE',
+  AlreadyPrepared = 'E_ALREADY_PREPARED',
+  Pending = 'E_PENDING',
+  ConnectionClosed = 'E_CONNECTION_CLOSED',
   // Additional detailed errors (Android-focused, kept cross-platform)
-  E_INIT_CONNECTION = 'E_INIT_CONNECTION',
-  E_SERVICE_DISCONNECTED = 'E_SERVICE_DISCONNECTED',
-  E_QUERY_PRODUCT = 'E_QUERY_PRODUCT',
-  E_SKU_NOT_FOUND = 'E_SKU_NOT_FOUND',
-  E_SKU_OFFER_MISMATCH = 'E_SKU_OFFER_MISMATCH',
-  E_ITEM_NOT_OWNED = 'E_ITEM_NOT_OWNED',
-  E_BILLING_UNAVAILABLE = 'E_BILLING_UNAVAILABLE',
-  E_FEATURE_NOT_SUPPORTED = 'E_FEATURE_NOT_SUPPORTED',
-  E_EMPTY_SKU_LIST = 'E_EMPTY_SKU_LIST',
+  InitConnection = 'E_INIT_CONNECTION',
+  ServiceDisconnected = 'E_SERVICE_DISCONNECTED',
+  QueryProduct = 'E_QUERY_PRODUCT',
+  SkuNotFound = 'E_SKU_NOT_FOUND',
+  SkuOfferMismatch = 'E_SKU_OFFER_MISMATCH',
+  ItemNotOwned = 'E_ITEM_NOT_OWNED',
+  BillingUnavailable = 'E_BILLING_UNAVAILABLE',
+  FeatureNotSupported = 'E_FEATURE_NOT_SUPPORTED',
+  EmptySkuList = 'E_EMPTY_SKU_LIST',
 }
 
 // Fast lookup set for validating standardized error code strings
@@ -128,42 +141,42 @@ const OPENIAP_ERROR_CODE_SET: Set<string> = new Set(
  */
 // Shared OpenIAP string code mapping for both platforms
 const COMMON_ERROR_CODE_MAP = {
-  [ErrorCode.E_UNKNOWN]: 'E_UNKNOWN',
-  [ErrorCode.E_USER_CANCELLED]: 'E_USER_CANCELLED',
-  [ErrorCode.E_USER_ERROR]: 'E_USER_ERROR',
-  [ErrorCode.E_ITEM_UNAVAILABLE]: 'E_ITEM_UNAVAILABLE',
-  [ErrorCode.E_REMOTE_ERROR]: 'E_REMOTE_ERROR',
-  [ErrorCode.E_NETWORK_ERROR]: 'E_NETWORK_ERROR',
-  [ErrorCode.E_SERVICE_ERROR]: 'E_SERVICE_ERROR',
-  [ErrorCode.E_RECEIPT_FAILED]: 'E_RECEIPT_FAILED',
-  [ErrorCode.E_RECEIPT_FINISHED]: 'E_RECEIPT_FINISHED',
-  [ErrorCode.E_RECEIPT_FINISHED_FAILED]: 'E_RECEIPT_FINISHED_FAILED',
-  [ErrorCode.E_NOT_PREPARED]: 'E_NOT_PREPARED',
-  [ErrorCode.E_NOT_ENDED]: 'E_NOT_ENDED',
-  [ErrorCode.E_ALREADY_OWNED]: 'E_ALREADY_OWNED',
-  [ErrorCode.E_DEVELOPER_ERROR]: 'E_DEVELOPER_ERROR',
-  [ErrorCode.E_BILLING_RESPONSE_JSON_PARSE_ERROR]:
+  [ErrorCode.Unknown]: 'E_UNKNOWN',
+  [ErrorCode.UserCancelled]: 'E_USER_CANCELLED',
+  [ErrorCode.UserError]: 'E_USER_ERROR',
+  [ErrorCode.ItemUnavailable]: 'E_ITEM_UNAVAILABLE',
+  [ErrorCode.RemoteError]: 'E_REMOTE_ERROR',
+  [ErrorCode.NetworkError]: 'E_NETWORK_ERROR',
+  [ErrorCode.ServiceError]: 'E_SERVICE_ERROR',
+  [ErrorCode.ReceiptFailed]: 'E_RECEIPT_FAILED',
+  [ErrorCode.ReceiptFinished]: 'E_RECEIPT_FINISHED',
+  [ErrorCode.ReceiptFinishedFailed]: 'E_RECEIPT_FINISHED_FAILED',
+  [ErrorCode.NotPrepared]: 'E_NOT_PREPARED',
+  [ErrorCode.NotEnded]: 'E_NOT_ENDED',
+  [ErrorCode.AlreadyOwned]: 'E_ALREADY_OWNED',
+  [ErrorCode.DeveloperError]: 'E_DEVELOPER_ERROR',
+  [ErrorCode.BillingResponseJsonParseError]:
     'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
-  [ErrorCode.E_DEFERRED_PAYMENT]: 'E_DEFERRED_PAYMENT',
-  [ErrorCode.E_INTERRUPTED]: 'E_INTERRUPTED',
-  [ErrorCode.E_IAP_NOT_AVAILABLE]: 'E_IAP_NOT_AVAILABLE',
-  [ErrorCode.E_PURCHASE_ERROR]: 'E_PURCHASE_ERROR',
-  [ErrorCode.E_SYNC_ERROR]: 'E_SYNC_ERROR',
-  [ErrorCode.E_TRANSACTION_VALIDATION_FAILED]:
+  [ErrorCode.DeferredPayment]: 'E_DEFERRED_PAYMENT',
+  [ErrorCode.Interrupted]: 'E_INTERRUPTED',
+  [ErrorCode.IapNotAvailable]: 'E_IAP_NOT_AVAILABLE',
+  [ErrorCode.PurchaseError]: 'E_PURCHASE_ERROR',
+  [ErrorCode.SyncError]: 'E_SYNC_ERROR',
+  [ErrorCode.TransactionValidationFailed]:
     'E_TRANSACTION_VALIDATION_FAILED',
-  [ErrorCode.E_ACTIVITY_UNAVAILABLE]: 'E_ACTIVITY_UNAVAILABLE',
-  [ErrorCode.E_ALREADY_PREPARED]: 'E_ALREADY_PREPARED',
-  [ErrorCode.E_PENDING]: 'E_PENDING',
-  [ErrorCode.E_CONNECTION_CLOSED]: 'E_CONNECTION_CLOSED',
-  [ErrorCode.E_INIT_CONNECTION]: 'E_INIT_CONNECTION',
-  [ErrorCode.E_SERVICE_DISCONNECTED]: 'E_SERVICE_DISCONNECTED',
-  [ErrorCode.E_QUERY_PRODUCT]: 'E_QUERY_PRODUCT',
-  [ErrorCode.E_SKU_NOT_FOUND]: 'E_SKU_NOT_FOUND',
-  [ErrorCode.E_SKU_OFFER_MISMATCH]: 'E_SKU_OFFER_MISMATCH',
-  [ErrorCode.E_ITEM_NOT_OWNED]: 'E_ITEM_NOT_OWNED',
-  [ErrorCode.E_BILLING_UNAVAILABLE]: 'E_BILLING_UNAVAILABLE',
-  [ErrorCode.E_FEATURE_NOT_SUPPORTED]: 'E_FEATURE_NOT_SUPPORTED',
-  [ErrorCode.E_EMPTY_SKU_LIST]: 'E_EMPTY_SKU_LIST',
+  [ErrorCode.ActivityUnavailable]: 'E_ACTIVITY_UNAVAILABLE',
+  [ErrorCode.AlreadyPrepared]: 'E_ALREADY_PREPARED',
+  [ErrorCode.Pending]: 'E_PENDING',
+  [ErrorCode.ConnectionClosed]: 'E_CONNECTION_CLOSED',
+  [ErrorCode.InitConnection]: 'E_INIT_CONNECTION',
+  [ErrorCode.ServiceDisconnected]: 'E_SERVICE_DISCONNECTED',
+  [ErrorCode.QueryProduct]: 'E_QUERY_PRODUCT',
+  [ErrorCode.SkuNotFound]: 'E_SKU_NOT_FOUND',
+  [ErrorCode.SkuOfferMismatch]: 'E_SKU_OFFER_MISMATCH',
+  [ErrorCode.ItemNotOwned]: 'E_ITEM_NOT_OWNED',
+  [ErrorCode.BillingUnavailable]: 'E_BILLING_UNAVAILABLE',
+  [ErrorCode.FeatureNotSupported]: 'E_FEATURE_NOT_SUPPORTED',
+  [ErrorCode.EmptySkuList]: 'E_EMPTY_SKU_LIST',
 } as const;
 
 export const ErrorCodeMapping = {
@@ -228,7 +241,7 @@ export class PurchaseError implements Error {
   ): PurchaseError {
     const errorCode = errorData.code
       ? ErrorCodeUtils.fromPlatformCode(errorData.code, platform)
-      : ErrorCode.E_UNKNOWN;
+      : ErrorCode.Unknown;
 
     return new PurchaseError({
       message: errorData.message || 'Unknown error occurred',
@@ -298,7 +311,7 @@ export const ErrorCodeUtils = {
       }
     }
 
-    return ErrorCode.E_UNKNOWN;
+    return ErrorCode.Unknown;
   },
 
   /**
@@ -391,6 +404,7 @@ export interface RequestPurchaseAndroidProps {
  */
 export interface RequestSubscriptionAndroidProps
   extends RequestPurchaseAndroidProps {
+  readonly purchaseTokenAndroid?: string;
   readonly replacementModeAndroid?: number;
   readonly subscriptionOffers: {
     sku: string;

--- a/src/ExpoIap.types.ts
+++ b/src/ExpoIap.types.ts
@@ -72,6 +72,9 @@ export type ProductSubscription =
   | (ProductSubscriptionAndroid & AndroidPlatform)
   | (ProductSubscriptionIOS & IosPlatform);
 
+// Legacy naming retained for backward compatibility
+export type SubscriptionProduct = ProductSubscription;
+
 // Re-export all platform-specific types to avoid deep imports
 export * from './types/ExpoIapAndroid.types';
 export * from './types/ExpoIapIOS.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
   PurchaseResult,
   RequestSubscriptionProps,
   RequestPurchaseProps,
-  SubscriptionProduct,
+  ProductSubscription,
   // Bring platform types from the barrel to avoid deep imports
   PurchaseAndroid,
   PaymentDiscount,
@@ -169,11 +169,11 @@ export const fetchProducts = async ({
 }: {
   skus: string[];
   type?: 'inapp' | 'subs';
-}): Promise<Product[] | SubscriptionProduct[]> => {
+}): Promise<Product[] | ProductSubscription[]> => {
   if (!skus?.length) {
     throw new PurchaseError({
       message: 'No SKUs provided',
-      code: ErrorCode.E_EMPTY_SKU_LIST,
+      code: ErrorCode.EmptySkuList,
     });
   }
 
@@ -195,7 +195,7 @@ export const fetchProducts = async ({
 
     return type === 'inapp'
       ? (filteredItems as Product[])
-      : (filteredItems as SubscriptionProduct[]);
+      : (filteredItems as ProductSubscription[]);
   }
 
   if (Platform.OS === 'android') {
@@ -213,7 +213,7 @@ export const fetchProducts = async ({
 
     return type === 'inapp'
       ? (filteredItems as Product[])
-      : (filteredItems as SubscriptionProduct[]);
+      : (filteredItems as ProductSubscription[]);
   }
 
   throw new Error('Unsupported platform');

--- a/src/types/ExpoIapAndroid.types.ts
+++ b/src/types/ExpoIapAndroid.types.ts
@@ -22,7 +22,7 @@ type PricingPhasesAndroid = {
 
 type ProductSubscriptionAndroidOfferDetail = {
   basePlanId: string;
-  offerId: string | null;
+  offerId?: string | null;
   offerToken: string;
   offerTags: string[];
   pricingPhases: PricingPhasesAndroid;
@@ -37,7 +37,7 @@ export type ProductAndroid = ProductCommon & {
 
 type ProductSubscriptionAndroidOfferDetails = {
   basePlanId: string;
-  offerId: string | null;
+  offerId?: string | null;
   offerToken: string;
   pricingPhases: PricingPhasesAndroid;
   offerTags: string[];
@@ -46,9 +46,6 @@ type ProductSubscriptionAndroidOfferDetails = {
 export type ProductSubscriptionAndroid = ProductAndroid & {
   subscriptionOfferDetailsAndroid: ProductSubscriptionAndroidOfferDetails[];
 };
-
-// Legacy naming for backward compatibility
-export type SubscriptionProductAndroid = ProductSubscriptionAndroid;
 
 export type RequestPurchaseAndroidProps = {
   skus: string[];

--- a/src/types/ExpoIapIOS.types.ts
+++ b/src/types/ExpoIapIOS.types.ts
@@ -1,10 +1,10 @@
 import {PurchaseCommon, ProductCommon} from '../ExpoIap.types';
 
 export enum ProductTypeIOS {
-  consumable = 'consumable',
-  nonConsumable = 'nonConsumable',
-  autoRenewableSubscription = 'autoRenewableSubscription',
-  nonRenewingSubscription = 'nonRenewingSubscription',
+  Consumable = 'consumable',
+  NonConsumable = 'nonConsumable',
+  AutoRenewableSubscription = 'autoRenewableSubscription',
+  NonRenewingSubscription = 'nonRenewingSubscription',
 }
 
 type SubscriptionIosPeriod = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR' | '';

--- a/src/types/ExpoIapIOS.types.ts
+++ b/src/types/ExpoIapIOS.types.ts
@@ -1,5 +1,12 @@
 import {PurchaseCommon, ProductCommon} from '../ExpoIap.types';
 
+export enum ProductTypeIOS {
+  consumable = 'consumable',
+  nonConsumable = 'nonConsumable',
+  autoRenewableSubscription = 'autoRenewableSubscription',
+  nonRenewingSubscription = 'nonRenewingSubscription',
+}
+
 type SubscriptionIosPeriod = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR' | '';
 type PaymentMode = '' | 'FREETRIAL' | 'PAYASYOUGO' | 'PAYUPFRONT';
 
@@ -31,6 +38,7 @@ export type ProductIOS = ProductCommon & {
   isFamilyShareableIOS: boolean;
   jsonRepresentationIOS: string;
   platform: 'ios';
+  typeIOS: ProductTypeIOS;
   subscriptionInfoIOS?: SubscriptionInfo;
   introductoryPriceNumberOfPeriodsIOS?: string;
   introductoryPriceSubscriptionPeriodIOS?: SubscriptionIosPeriod;
@@ -57,9 +65,6 @@ export type ProductSubscriptionIOS = ProductIOS & {
   subscriptionPeriodNumberIOS?: string;
   subscriptionPeriodUnitIOS?: SubscriptionIosPeriod;
 };
-
-// Legacy naming for backward compatibility
-export type SubscriptionProductIOS = ProductSubscriptionIOS;
 
 export type PaymentDiscount = {
   /**

--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -31,7 +31,7 @@ import {
   Purchase,
   PurchaseError,
   PurchaseResult,
-  SubscriptionProduct,
+  ProductSubscription,
   RequestPurchaseProps,
   RequestSubscriptionProps,
   ErrorCode,
@@ -51,7 +51,7 @@ type UseIap = {
   products: Product[];
   promotedProductsIOS: Purchase[];
   promotedProductIdIOS?: string;
-  subscriptions: SubscriptionProduct[];
+  subscriptions: ProductSubscription[];
   availablePurchases: Purchase[];
   currentPurchase?: Purchase;
   currentPurchaseError?: PurchaseError;
@@ -108,7 +108,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   const [connected, setConnected] = useState<boolean>(false);
   const [products, setProducts] = useState<Product[]>([]);
   const [promotedProductsIOS] = useState<Purchase[]>([]);
-  const [subscriptions, setSubscriptions] = useState<SubscriptionProduct[]>([]);
+  const [subscriptions, setSubscriptions] = useState<ProductSubscription[]>([]);
 
   const [availablePurchases, setAvailablePurchases] = useState<Purchase[]>([]);
   const [currentPurchase, setCurrentPurchase] = useState<Purchase>();
@@ -159,7 +159,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     promotedProductIOS?: EventSubscription;
   }>({});
 
-  const subscriptionsRefState = useRef<SubscriptionProduct[]>([]);
+  const subscriptionsRefState = useRef<ProductSubscription[]>([]);
 
   useEffect(() => {
     subscriptionsRefState.current = subscriptions;
@@ -180,7 +180,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
         setSubscriptions((prevSubscriptions) =>
           mergeWithDuplicateCheck(
             prevSubscriptions,
-            result as SubscriptionProduct[],
+            result as ProductSubscription[],
             (subscription) => subscription.id,
           ),
         );
@@ -203,7 +203,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
           setSubscriptions((prevSubscriptions) =>
             mergeWithDuplicateCheck(
               prevSubscriptions,
-              result as SubscriptionProduct[],
+              result as ProductSubscription[],
               (subscription) => subscription.id,
             ),
           );
@@ -386,7 +386,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
       (error: PurchaseError) => {
         if (
           !connectedRef.current &&
-          error.code === ErrorCode.E_INIT_CONNECTION
+          error.code === ErrorCode.InitConnection
         ) {
           return; // Ignore initialization error before connected
         }

--- a/src/utils/__tests__/errorMapping.test.ts
+++ b/src/utils/__tests__/errorMapping.test.ts
@@ -8,29 +8,29 @@ import {ErrorCode} from '../../ExpoIap.types';
 
 describe('errorMapping utils', () => {
   it('detects user cancelled errors from string or object', () => {
-    expect(isUserCancelledError(ErrorCode.E_USER_CANCELLED)).toBe(true);
-    expect(isUserCancelledError({code: ErrorCode.E_USER_CANCELLED})).toBe(true);
+    expect(isUserCancelledError(ErrorCode.UserCancelled)).toBe(true);
+    expect(isUserCancelledError({code: ErrorCode.UserCancelled})).toBe(true);
     expect(isUserCancelledError('other')).toBe(false);
   });
 
   it('detects network related errors', () => {
-    expect(isNetworkError(ErrorCode.E_NETWORK_ERROR)).toBe(true);
-    expect(isNetworkError({code: ErrorCode.E_SERVICE_DISCONNECTED})).toBe(true);
+    expect(isNetworkError(ErrorCode.NetworkError)).toBe(true);
+    expect(isNetworkError({code: ErrorCode.ServiceDisconnected})).toBe(true);
     expect(isNetworkError('random')).toBe(false);
   });
 
   it('detects recoverable errors', () => {
-    expect(isRecoverableError(ErrorCode.E_QUERY_PRODUCT)).toBe(true);
-    expect(isRecoverableError({code: ErrorCode.E_INIT_CONNECTION})).toBe(true);
+    expect(isRecoverableError(ErrorCode.QueryProduct)).toBe(true);
+    expect(isRecoverableError({code: ErrorCode.InitConnection})).toBe(true);
     expect(isRecoverableError('nonrecoverable')).toBe(false);
   });
 
   it('returns user friendly messages', () => {
     expect(
-      getUserFriendlyErrorMessage({code: ErrorCode.E_USER_CANCELLED}),
+      getUserFriendlyErrorMessage({code: ErrorCode.UserCancelled}),
     ).toMatch(/cancelled/i);
     expect(
-      getUserFriendlyErrorMessage({code: ErrorCode.E_EMPTY_SKU_LIST}),
+      getUserFriendlyErrorMessage({code: ErrorCode.EmptySkuList}),
     ).toMatch(/No product IDs/i);
     expect(getUserFriendlyErrorMessage({code: 'UNKNOWN'} as any)).toBe(
       'An unexpected error occurred',

--- a/src/utils/errorMapping.ts
+++ b/src/utils/errorMapping.ts
@@ -12,11 +12,11 @@ import {ErrorCode} from '../ExpoIap.types';
  */
 export function isUserCancelledError(error: any): boolean {
   if (typeof error === 'string') {
-    return error === ErrorCode.E_USER_CANCELLED;
+    return error === ErrorCode.UserCancelled;
   }
 
   if (error && error.code) {
-    return error.code === ErrorCode.E_USER_CANCELLED;
+    return error.code === ErrorCode.UserCancelled;
   }
 
   return false;
@@ -29,11 +29,11 @@ export function isUserCancelledError(error: any): boolean {
  */
 export function isNetworkError(error: any): boolean {
   const networkErrors = [
-    ErrorCode.E_NETWORK_ERROR,
-    ErrorCode.E_REMOTE_ERROR,
-    ErrorCode.E_SERVICE_ERROR,
-    ErrorCode.E_SERVICE_DISCONNECTED,
-    ErrorCode.E_BILLING_UNAVAILABLE,
+    ErrorCode.NetworkError,
+    ErrorCode.RemoteError,
+    ErrorCode.ServiceError,
+    ErrorCode.ServiceDisconnected,
+    ErrorCode.BillingUnavailable,
   ];
 
   const errorCode = typeof error === 'string' ? error : error?.code;
@@ -47,14 +47,14 @@ export function isNetworkError(error: any): boolean {
  */
 export function isRecoverableError(error: any): boolean {
   const recoverableErrors = [
-    ErrorCode.E_NETWORK_ERROR,
-    ErrorCode.E_REMOTE_ERROR,
-    ErrorCode.E_SERVICE_ERROR,
-    ErrorCode.E_INTERRUPTED,
-    ErrorCode.E_SERVICE_DISCONNECTED,
-    ErrorCode.E_BILLING_UNAVAILABLE,
-    ErrorCode.E_QUERY_PRODUCT,
-    ErrorCode.E_INIT_CONNECTION,
+    ErrorCode.NetworkError,
+    ErrorCode.RemoteError,
+    ErrorCode.ServiceError,
+    ErrorCode.Interrupted,
+    ErrorCode.ServiceDisconnected,
+    ErrorCode.BillingUnavailable,
+    ErrorCode.QueryProduct,
+    ErrorCode.InitConnection,
   ];
 
   const errorCode = typeof error === 'string' ? error : error?.code;
@@ -70,43 +70,43 @@ export function getUserFriendlyErrorMessage(error: any): string {
   const errorCode = typeof error === 'string' ? error : error?.code;
 
   switch (errorCode) {
-    case ErrorCode.E_USER_CANCELLED:
+    case ErrorCode.UserCancelled:
       return 'Purchase was cancelled by user';
-    case ErrorCode.E_NETWORK_ERROR:
+    case ErrorCode.NetworkError:
       return 'Network connection error. Please check your internet connection and try again.';
-    case ErrorCode.E_RECEIPT_FINISHED:
+    case ErrorCode.ReceiptFinished:
       return 'Receipt already finished';
-    case ErrorCode.E_SERVICE_DISCONNECTED:
+    case ErrorCode.ServiceDisconnected:
       return 'Billing service disconnected. Please try again.';
-    case ErrorCode.E_BILLING_UNAVAILABLE:
+    case ErrorCode.BillingUnavailable:
       return 'Billing is unavailable on this device or account.';
-    case ErrorCode.E_ITEM_UNAVAILABLE:
+    case ErrorCode.ItemUnavailable:
       return 'This item is not available for purchase';
-    case ErrorCode.E_ITEM_NOT_OWNED:
+    case ErrorCode.ItemNotOwned:
       return "You don't own this item";
-    case ErrorCode.E_ALREADY_OWNED:
+    case ErrorCode.AlreadyOwned:
       return 'You already own this item';
-    case ErrorCode.E_SKU_NOT_FOUND:
+    case ErrorCode.SkuNotFound:
       return 'Requested product could not be found';
-    case ErrorCode.E_SKU_OFFER_MISMATCH:
+    case ErrorCode.SkuOfferMismatch:
       return 'Selected offer does not match the SKU';
-    case ErrorCode.E_DEFERRED_PAYMENT:
+    case ErrorCode.DeferredPayment:
       return 'Payment is pending approval';
-    case ErrorCode.E_NOT_PREPARED:
+    case ErrorCode.NotPrepared:
       return 'In-app purchase is not ready. Please try again later.';
-    case ErrorCode.E_SERVICE_ERROR:
+    case ErrorCode.ServiceError:
       return 'Store service error. Please try again later.';
-    case ErrorCode.E_FEATURE_NOT_SUPPORTED:
+    case ErrorCode.FeatureNotSupported:
       return 'This feature is not supported on this device.';
-    case ErrorCode.E_TRANSACTION_VALIDATION_FAILED:
+    case ErrorCode.TransactionValidationFailed:
       return 'Transaction could not be verified';
-    case ErrorCode.E_RECEIPT_FAILED:
+    case ErrorCode.ReceiptFailed:
       return 'Receipt processing failed';
-    case ErrorCode.E_EMPTY_SKU_LIST:
+    case ErrorCode.EmptySkuList:
       return 'No product IDs provided';
-    case ErrorCode.E_INIT_CONNECTION:
+    case ErrorCode.InitConnection:
       return 'Failed to initialize billing connection';
-    case ErrorCode.E_QUERY_PRODUCT:
+    case ErrorCode.QueryProduct:
       return 'Failed to query products. Please try again later.';
     default:
       return error?.message || 'An unexpected error occurred';


### PR DESCRIPTION
## Summary
- Sync public purchase types with react-native-iap #3006
- Replace legacy ErrorCode.E_* references with camelCase enums

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added PurchaseState enum and richer purchase data (quantity, isAutoRenewing, legacy transactionId).
  - Introduced ProductTypeIOS and ProductIOS.typeIOS.
  - Android: added optional purchaseTokenAndroid; made subscription offerId fields optional.

- Refactor
  - Renamed SubscriptionProduct to ProductSubscription across APIs (backward-compat alias retained).
  - Renamed ErrorCode members from E_* to PascalCase (e.g., UserCancelled, NetworkError).
  - Updated fetchProducts/useIAP types to use ProductSubscription.

- Documentation
  - Migration guides, API docs, and examples updated to new type and error-code names.

- Tests
  - Adjusted to new ErrorCode identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->