### PR TITLE
Align OpenIAP literal unions

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -81,7 +81,7 @@ export interface Platform {
 // ✅ Good - Clear parameter and return types
 export const requestProducts = async (params: {
   skus: string[];
-  type?: 'inapp' | 'subs';
+  type?: 'in-app' | 'subs';
 }): Promise<Product[]> => {
   // implementation
 };
@@ -141,7 +141,7 @@ export const deepLinkToSubscriptionsAndroid = async ({
 // These functions handle platform differences internally
 export const requestProducts = async (params: {
   skus: string[];
-  type?: 'inapp' | 'subs';
+  type?: 'in-app' | 'subs';
 }): Promise<Product[]> => {
   return (
     Platform.select({
@@ -274,7 +274,7 @@ Always use async/await over promises:
 // ✅ Good
 export const requestProducts = async (params: {
   skus: string[];
-  type?: 'inapp' | 'subs';
+  type?: 'in-app' | 'subs';
 }): Promise<Product[]> => {
   try {
     const products = await ExpoIapModule.requestProducts(params);
@@ -312,14 +312,14 @@ All public APIs must have JSDoc comments:
  *
  * @example
  * ```typescript
- * const products = await requestProducts({ skus: ['com.example.premium'], type: 'inapp' });
+ * const products = await requestProducts({ skus: ['com.example.premium'], type: 'in-app' });
  * ```
  *
  * @platform iOS
  */
 export const requestProductsIOS = async (params: {
   skus: string[];
-  type?: 'inapp' | 'subs';
+  type?: 'in-app' | 'subs';
 }): Promise<ProductIOS[]> => {
   // implementation
 };
@@ -358,7 +358,7 @@ describe('PurchaseManager', () => {
     it('should get products on iOS', async () => {
       const products = await requestProductsIOS({
         skus: ['com.example.product'],
-        type: 'inapp',
+        type: 'in-app',
       });
       expect(products).toHaveLength(1);
     });
@@ -371,7 +371,7 @@ describe('PurchaseManager', () => {
 
     it('should throw error on Android', async () => {
       await expect(
-        requestProductsIOS({skus: ['com.example.product'], type: 'inapp'}),
+        requestProductsIOS({skus: ['com.example.product'], type: 'in-app'}),
       ).rejects.toThrow('This method is only available on iOS');
     });
   });
@@ -487,7 +487,7 @@ await requestPurchase({
       obfuscatedAccountIdAndroid: 'user-123',
     },
   },
-  type: 'inapp',
+  type: 'in-app',
 });
 
 // ❌ Bad - Old API with Platform.OS checks

--- a/docs/blog/2025-08-18-v2.8.0-migration-guide.md
+++ b/docs/blog/2025-08-18-v2.8.0-migration-guide.md
@@ -161,7 +161,7 @@ const purchase = await requestPurchase({
     ios: {sku: 'product-id'},
     android: {skus: ['product-id']},
   },
-  type: 'inapp',
+  type: 'in-app',
 });
 if (purchase.expirationDateIOS) {
   console.log('Expires:', purchase.expirationDateIOS);

--- a/docs/blog/2025-09-03-v2.8.7.md
+++ b/docs/blog/2025-09-03-v2.8.7.md
@@ -23,10 +23,10 @@ import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
 
 ```typescript
 // Old (deprecated)
-const products = await requestProducts({skus: ['product1'], type: 'inapp'});
+const products = await requestProducts({skus: ['product1'], type: 'in-app'});
 
 // New (recommended)
-const products = await fetchProducts({skus: ['product1'], type: 'inapp'});
+const products = await fetchProducts({skus: ['product1'], type: 'in-app'});
 ```
 
 ### useIAP Hook
@@ -34,7 +34,7 @@ const products = await fetchProducts({skus: ['product1'], type: 'inapp'});
 ```typescript
 const {fetchProducts, requestProducts} = useIAP(); // requestProducts still works but deprecated
 
-await fetchProducts({skus: ['product1'], type: 'inapp'});
+await fetchProducts({skus: ['product1'], type: 'in-app'});
 ```
 
 ## Deprecations

--- a/docs/blog/2025-09-13-v3.0.0.md
+++ b/docs/blog/2025-09-13-v3.0.0.md
@@ -54,7 +54,7 @@ import AdFitTopFixed from "@site/src/uis/AdFitTopFixed";
 ```ts
 import {fetchProducts, type ProductSubscription} from 'expo-iap';
 
-const inapps = await fetchProducts({skus: ['prod1', 'prod2'], type: 'inapp'});
+const inapps = await fetchProducts({skus: ['prod1', 'prod2'], type: 'in-app'});
 
 const subs = (await fetchProducts({
   skus: ['sub_monthly'],
@@ -70,7 +70,7 @@ import {requestPurchase} from 'expo-iap';
 // In‑app
 await requestPurchase({
   request: {ios: {sku: 'prod1'}, android: {skus: ['prod1']}},
-  type: 'inapp',
+  type: 'in-app',
 });
 
 // Subscriptions (Android supply offer tokens)

--- a/docs/docs/api/methods/core-methods.md
+++ b/docs/docs/api/methods/core-methods.md
@@ -84,7 +84,7 @@ const loadProducts = async () => {
   try {
     const products = await fetchProducts({
       skus: ['com.example.product1', 'com.example.product2'],
-      type: 'inapp',
+      type: 'in-app',
     });
 
     console.log('Products:', products);
@@ -114,7 +114,7 @@ const loadSubscriptions = async () => {
 
 - `params` (object):
   - `skus` (string[]): Array of product or subscription IDs to fetch
-  - `type` ('inapp' | 'subs'): Product type - 'inapp' for products, 'subs' for subscriptions
+  - `type` ('in-app' | 'subs'): Product type - 'in-app' for products, 'subs' for subscriptions
 
 **Returns:** `Promise<Product[]>`
 
@@ -149,7 +149,7 @@ const buyProduct = async (productId: string) => {
           skus: [productId],
         },
       },
-      type: 'inapp',
+      type: 'in-app',
     });
   } catch (error) {
     console.error('Purchase failed:', error);
@@ -193,7 +193,7 @@ await requestPurchase({
     quantity: 1,
     appAccountToken: 'user-account-token',
   },
-  type: 'inapp',
+  type: 'in-app',
 });
 ```
 
@@ -206,7 +206,7 @@ await requestPurchase({
     obfuscatedAccountIdAndroid: 'user-account-id',
     obfuscatedProfileIdAndroid: 'user-profile-id',
   },
-  type: 'inapp',
+  type: 'in-app',
 });
 ```
 
@@ -222,7 +222,7 @@ await requestPurchase({
     - `obfuscatedAccountIdAndroid?` (string, Android only): Obfuscated account ID
     - `obfuscatedProfileIdAndroid?` (string, Android only): Obfuscated profile ID
     - `isOfferPersonalized?` (boolean, Android only): Whether offer is personalized
-  - `type?` ('inapp' | 'subs'): Purchase type, defaults to 'inapp'
+  - `type?` ('in-app' | 'subs'): Purchase type, defaults to 'in-app'
 
 **Returns:** `Promise<Purchase | Purchase[] | void>`
 
@@ -776,6 +776,6 @@ This ensures pending transactions are surfaced and properly resolved without a s
 ## Removed APIs
 
 - `requestProducts()` — Removed in v3.0.0. Use `fetchProducts({ skus, type })` instead.
-- `getProducts()` — Removed in v3.0.0. Use `fetchProducts({ skus, type: 'inapp' })` instead.
+- `getProducts()` — Removed in v3.0.0. Use `fetchProducts({ skus, type: 'in-app' })` instead.
 - `getSubscriptions()` — Removed in v3.0.0. Use `fetchProducts({ skus, type: 'subs' })` instead.
 - `requestSubscription()` — Removed in v3.0.0. Use `requestPurchase({ ..., type: 'subs' })` and supply Android `subscriptionOffers`.

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -14,27 +14,20 @@ Key runtime helpers that build on these types live alongside them:
 
 Below is a curated overview of the most commonly used types. Consult `src/types.ts` for the full schema.
 
-## Core Enumerations
+## Core Type Aliases
 
 ```ts
-export enum Platform {
-  Android = 'ANDROID',
-  Ios = 'IOS',
-}
+export type IapPlatform = 'android' | 'ios';
 
-export enum ProductType {
-  InApp = 'IN_APP',
-  Subs = 'SUBS',
-}
+export type ProductType = 'in-app' | 'subs';
 
-export enum PurchaseState {
-  Deferred = 'DEFERRED',
-  Failed = 'FAILED',
-  Pending = 'PENDING',
-  Purchased = 'PURCHASED',
-  Restored = 'RESTORED',
-  Unknown = 'UNKNOWN',
-}
+export type PurchaseState =
+  | 'deferred'
+  | 'failed'
+  | 'pending'
+  | 'purchased'
+  | 'restored'
+  | 'unknown';
 ```
 
 The `ErrorCode` enum now mirrors the OpenIAP schema without the legacy `E_` prefix:
@@ -54,7 +47,7 @@ Use `PurchaseError` from `src/purchase-error.ts` to work with typed errors and p
 
 ## Product Types
 
-All products share the generated `ProductCommon` interface. Platform extensions discriminate on the `platform` field via the `Platform` enum.
+All products share the generated `ProductCommon` interface. Platform extensions discriminate on the `platform` field via the `IapPlatform` string union.
 
 ```ts
 export interface ProductCommon {
@@ -66,7 +59,7 @@ export interface ProductCommon {
   displayPrice: string;
   currency: string;
   price?: number | null;
-  platform: Platform;
+  platform: IapPlatform;
 }
 
 export interface ProductAndroid extends ProductCommon {
@@ -77,29 +70,29 @@ export interface ProductAndroid extends ProductCommon {
     | null;
 }
 
-export interface ProductIos extends ProductCommon {
+export interface ProductIOS extends ProductCommon {
   displayNameIOS: string;
   isFamilyShareableIOS: boolean;
   jsonRepresentationIOS: string;
-  typeIOS: ProductTypeIos;
-  subscriptionInfoIOS?: SubscriptionInfoIos | null;
+  typeIOS: ProductTypeIOS;
+  subscriptionInfoIOS?: SubscriptionInfoIOS | null;
 }
 
-export type Product = ProductAndroid | ProductIos;
+export type Product = ProductAndroid | ProductIOS;
 export type ProductSubscription =
   | ProductSubscriptionAndroid
-  | ProductSubscriptionIos;
+  | ProductSubscriptionIOS;
 ```
 
 ## Purchase Types
 
-Purchases share the `PurchaseCommon` shape and discriminate on the same `platform` enum. Both variants expose the unified `purchaseToken` field for server validation.
+Purchases share the `PurchaseCommon` shape and discriminate on the same `platform` union. Both variants expose the unified `purchaseToken` field for server validation.
 
 ```ts
 export interface PurchaseCommon {
   id: string;
   productId: string;
-  platform: Platform;
+  platform: IapPlatform;
   purchaseState: PurchaseState;
   transactionDate: number;
   quantity: number;
@@ -115,15 +108,15 @@ export interface PurchaseAndroid extends PurchaseCommon {
   dataAndroid?: string | null;
 }
 
-export interface PurchaseIos extends PurchaseCommon {
+export interface PurchaseIOS extends PurchaseCommon {
   appAccountToken?: string | null;
   environmentIOS?: string | null;
   expirationDateIOS?: number | null;
   originalTransactionIdentifierIOS?: string | null;
-  offerIOS?: PurchaseOfferIos | null;
+  offerIOS?: PurchaseOfferIOS | null;
 }
 
-export type Purchase = PurchaseAndroid | PurchaseIos;
+export type Purchase = PurchaseAndroid | PurchaseIOS;
 ```
 
 ## Active Subscriptions

--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -134,7 +134,7 @@ interface UseIAPOptions {
   ```tsx
   if (connected) {
     // Safe to make IAP calls
-    fetchProducts({skus: ['product.id'], type: 'inapp'});
+    fetchProducts({skus: ['product.id'], type: 'in-app'});
   }
   ```
 
@@ -219,7 +219,7 @@ interface UseIAPOptions {
 
 #### fetchProducts
 
-- **Type**: `(params: { skus: string[]; type?: 'inapp' | 'subs' }) => Promise<void>`
+- **Type**: `(params: { skus: string[]; type?: 'in-app' | 'subs' }) => Promise<void>`
 - **Description**: Fetch products or subscriptions and update `products` / `subscriptions` state. In the hook this returns `void` (no data result), by design.
 - **Do not await for data**: Call it, then consume `products` / `subscriptions` state from the hook.
 - **Example**:
@@ -230,7 +230,7 @@ interface UseIAPOptions {
     // In hook: returns void, updates state
     fetchProducts({
       skus: ['com.app.premium', 'com.app.coins_100'],
-      type: 'inapp',
+      type: 'in-app',
     });
     fetchProducts({skus: ['com.app.premium_monthly'], type: 'subs'});
   }, [connected, fetchProducts]);
@@ -507,7 +507,7 @@ const {requestPurchase} = useIAP({
    ```tsx
    useEffect(() => {
      if (connected) {
-       fetchProducts({skus: productIds, type: 'inapp'});
+       fetchProducts({skus: productIds, type: 'in-app'});
      }
    }, [connected, fetchProducts]);
    ```

--- a/docs/docs/examples/purchase-flow.md
+++ b/docs/docs/examples/purchase-flow.md
@@ -22,11 +22,11 @@ View the full example source:
 
 - Load products:
 
-  `fetchProducts({ skus, type: 'inapp' })`
+  `fetchProducts({ skus, type: 'in-app' })`
 
 - Start purchase:
 
-  `requestPurchase({ request: { ios: { sku }, android: { skus: [sku] } }, type: 'inapp' })`
+  `requestPurchase({ request: { ios: { sku }, android: { skus: [sku] } }, type: 'in-app' })`
 
 - Receive callbacks: `onPurchaseSuccess` / `onPurchaseError` (from `useIAP`)
 
@@ -80,7 +80,7 @@ await requestPurchase({
     ios: {sku: productId, quantity: 1},
     android: {skus: [productId]},
   },
-  type: 'inapp',
+  type: 'in-app',
 });
 ```
 

--- a/docs/docs/getting-started/setup-android.md
+++ b/docs/docs/getting-started/setup-android.md
@@ -54,7 +54,7 @@ function App() {
       // Fetch products and subscriptions
       fetchProducts({
         skus: androidProductIds.filter((id) => !id.includes('subscription')),
-        type: 'inapp',
+        type: 'in-app',
       });
       fetchProducts({
         skus: androidProductIds.filter((id) => id.includes('subscription')),
@@ -92,7 +92,7 @@ const AndroidProductItem = ({product}: {product: Product}) => {
     if (product.platform === 'android') {
       requestPurchase({
         request: {skus: [product.id]},
-        type: 'inapp',
+        type: 'in-app',
       });
     }
   };

--- a/docs/docs/getting-started/setup-ios.md
+++ b/docs/docs/getting-started/setup-ios.md
@@ -48,7 +48,7 @@ function App() {
 
   React.useEffect(() => {
     if (connected) {
-      fetchProducts({skus: productIds, type: 'inapp'});
+      fetchProducts({skus: productIds, type: 'in-app'});
     }
   }, [connected]);
 

--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -101,7 +101,7 @@ const {connected, requestProducts} = useIAP();
 
 useEffect(() => {
   if (connected) {
-    fetchProducts({skus: ['com.yourapp.product1'], type: 'inapp'});
+    fetchProducts({skus: ['com.yourapp.product1'], type: 'in-app'});
   }
 }, [connected]);
 ```
@@ -366,7 +366,7 @@ When using the `useIAP` hook:
 // No manual caching needed - just fetch when connected
 useEffect(() => {
   if (connected) {
-    fetchProducts({skus: productIds, type: 'inapp'});
+    fetchProducts({skus: productIds, type: 'in-app'});
   }
 }, [connected]);
 

--- a/docs/docs/guides/getting-started.md
+++ b/docs/docs/guides/getting-started.md
@@ -147,7 +147,7 @@ const productIds = [
 
 useEffect(() => {
   if (connected) {
-    fetchProducts({skus: productIds, type: 'inapp'});
+    fetchProducts({skus: productIds, type: 'in-app'});
   }
 }, [connected, fetchProducts]);
 ```

--- a/docs/docs/guides/ios-hot-reload-fix.md
+++ b/docs/docs/guides/ios-hot-reload-fix.md
@@ -14,7 +14,7 @@ During hot reload, concurrent IAP operations would fail:
 ```typescript
 // Would fail on iOS during hot reload
 await Promise.all([
-  fetchProducts({skus: productIds, type: 'inapp'}),
+  fetchProducts({skus: productIds, type: 'in-app'}),
   getAvailablePurchases(), // Returns empty or fails
 ]);
 ```
@@ -38,7 +38,7 @@ The iOS native module now:
 ```typescript
 // Now works correctly during hot reload
 const [products, purchases] = await Promise.all([
-  fetchProducts({skus: productIds, type: 'inapp'}),
+  fetchProducts({skus: productIds, type: 'in-app'}),
   getAvailablePurchases(),
 ]);
 ```

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -50,7 +50,7 @@ export default function App() {
     if (connected) {
       console.log('Connected to store');
       // You can now safely call store methods
-      fetchProducts({skus: ['product1', 'product2'], type: 'inapp'});
+      fetchProducts({skus: ['product1', 'product2'], type: 'in-app'});
     }
   }, [connected, requestProducts]);
 
@@ -227,7 +227,7 @@ function MyApp() {
 
   useEffect(() => {
     if (connected) {
-      fetchProducts({skus: productIds, type: 'inapp'});
+      fetchProducts({skus: productIds, type: 'in-app'});
     }
   }, [connected]);
 

--- a/docs/docs/guides/migration.md
+++ b/docs/docs/guides/migration.md
@@ -26,7 +26,7 @@ Quick mappings:
 
 ```ts
 // getProducts/getSubscriptions/requestProducts → fetchProducts
-await fetchProducts({skus: ['id1', 'id2'], type: 'inapp'});
+await fetchProducts({skus: ['id1', 'id2'], type: 'in-app'});
 
 // requestSubscription → requestPurchase with subs
 await requestPurchase({
@@ -323,10 +323,10 @@ purchaseUpdatedListener((purchase) => {
 
 ```tsx
 // ❌ Old (deprecated in v2.8.7)
-const products = await requestProducts({skus: ['product1'], type: 'inapp'});
+const products = await requestProducts({skus: ['product1'], type: 'in-app'});
 
 // ✅ New (v2.8.7+)
-const products = await fetchProducts({skus: ['product1'], type: 'inapp'});
+const products = await fetchProducts({skus: ['product1'], type: 'in-app'});
 ```
 
 ## API Changes
@@ -354,7 +354,7 @@ Most method signatures remain the same, but with improved TypeScript definitions
 
 ```tsx
 // Both libraries have the same signature
-await fetchProducts({skus: ['product1', 'product2'], type: 'inapp'});
+await fetchProducts({skus: ['product1', 'product2'], type: 'in-app'});
 await requestPurchase({request: {sku: 'product_id'}});
 await finishTransaction({purchase});
 await getPurchaseHistories(); // Note: plural form in expo-iap v2.6.0+
@@ -364,10 +364,10 @@ await getPurchaseHistories(); // Note: plural form in expo-iap v2.6.0+
 
 > **⚠️ Important:** The following methods are deprecated and will be removed in a future version:
 
-| Deprecated Method        | Replacement                              |
-| ------------------------ | ---------------------------------------- |
-| `getProducts(skus)`      | `fetchProducts({ skus, type: 'inapp' })` |
-| `getSubscriptions(skus)` | `fetchProducts({ skus, type: 'subs' })`  |
+| Deprecated Method        | Replacement                               |
+| ------------------------ | ----------------------------------------- |
+| `getProducts(skus)`      | `fetchProducts({ skus, type: 'in-app' })` |
+| `getSubscriptions(skus)` | `fetchProducts({ skus, type: 'subs' })`   |
 
 **Migration Examples:**
 
@@ -377,7 +377,7 @@ import {getProducts, getSubscriptions} from 'expo-iap';
 
 const products = await fetchProducts({
   skus: ['product1', 'product2'],
-  type: 'inapp',
+  type: 'in-app',
 });
 const subs = await fetchProducts({skus: ['sub1', 'sub2'], type: 'subs'});
 
@@ -386,7 +386,7 @@ import {fetchProducts} from 'expo-iap';
 
 const products = await fetchProducts({
   skus: ['product1', 'product2'],
-  type: 'inapp',
+  type: 'in-app',
 });
 
 const subs = await fetchProducts({skus: ['sub1', 'sub2'], type: 'subs'});
@@ -429,7 +429,7 @@ export default function MigrationTest() {
     if (connected) {
       console.log('✅ Connection successful');
 
-      fetchProducts({skus: ['test_product'], type: 'inapp'})
+      fetchProducts({skus: ['test_product'], type: 'in-app'})
         .then((products) => {
           console.log('✅ Products fetched:', products.length);
         })
@@ -458,7 +458,7 @@ const testPurchaseFlow = async () => {
     // 1. Fetch products
     const products = await fetchProducts({
       skus: ['test_product'],
-      type: 'inapp',
+      type: 'in-app',
     });
     console.log('✅ Products fetched');
 
@@ -480,7 +480,7 @@ Ensure error handling transitions properly:
 ```tsx
 const testErrorHandling = () => {
   // Test with invalid product ID
-  fetchProducts({skus: ['invalid_product'], type: 'inapp'})
+  fetchProducts({skus: ['invalid_product'], type: 'in-app'})
     .then((products) => {
       if (products.length === 0) {
         console.log('✅ Empty products handled correctly');

--- a/docs/docs/guides/purchases.md
+++ b/docs/docs/guides/purchases.md
@@ -180,7 +180,7 @@ export default function PurchaseScreen() {
     const initializeIAP = async () => {
       try {
         // Get both products and subscriptions
-        await fetchProducts({skus: bulbPackSkus, type: 'inapp'});
+        await fetchProducts({skus: bulbPackSkus, type: 'in-app'});
         await fetchProducts({skus: subscriptionSkus, type: 'subs'});
         setIsReady(true);
       } catch (error) {

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -44,7 +44,7 @@ const {connected, getProducts} = useIAP();
 useEffect(() => {
   if (connected) {
     // ✅ Only call requestProducts when connected
-    fetchProducts({skus: productIds, type: 'inapp'});
+    fetchProducts({skus: productIds, type: 'in-app'});
   } else {
     console.log('Not connected to store yet');
   }

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -71,7 +71,7 @@ Load your products when the store connects:
 useEffect(() => {
   if (connected) {
     // Fetch your products
-    fetchProducts({skus: productIds, type: 'inapp'});
+    fetchProducts({skus: productIds, type: 'in-app'});
   }
 }, [connected]);
 ```
@@ -171,7 +171,7 @@ export default function SimpleStore() {
 
   useEffect(() => {
     if (connected) {
-      fetchProducts({skus: productIds, type: 'inapp'});
+      fetchProducts({skus: productIds, type: 'in-app'});
     }
   }, [connected]);
 

--- a/example/README.md
+++ b/example/README.md
@@ -52,7 +52,7 @@ const result = await requestPurchase(...) as ProductPurchaseIos;
 // ✅ NEW WAY - Automatic type inference
 const result = await requestPurchase({
   request: { sku: 'product.id' },
-  type: 'inapp'
+  type: 'in-app'
 });
 // TypeScript automatically knows the correct return type!
 ```
@@ -66,7 +66,7 @@ const result = await requestPurchase({
     sku: 'product.id', // Universal property
     quantity: 1, // iOS-specific (ignored on Android)
   },
-  type: 'inapp',
+  type: 'in-app',
 });
 ```
 

--- a/example/__tests__/purchase-flow.test.tsx
+++ b/example/__tests__/purchase-flow.test.tsx
@@ -67,7 +67,7 @@ describe('PurchaseFlow Component', () => {
         ios: {sku: 'test.product.1', quantity: 1},
         android: {skus: ['test.product.1']},
       },
-      type: 'inapp',
+      type: 'in-app',
     });
   });
 });

--- a/example/__tests__/subscription-flow.test.tsx
+++ b/example/__tests__/subscription-flow.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {render, fireEvent} from '@testing-library/react-native';
 import {Alert, Platform} from 'react-native';
 import SubscriptionFlow from '../app/subscription-flow';
-import {PaymentModeIOS} from '../../src/types';
 
 // Mock Alert
 jest.spyOn(Alert, 'alert');
@@ -24,9 +23,9 @@ const createMockSubscription = (overrides = {}) => ({
   currency: 'USD',
   platform: 'ios',
   subscriptionInfoIOS: {
-    subscriptionPeriod: {unit: 'MONTH'},
+    subscriptionPeriod: {unit: 'month'},
     introductoryOffer: {
-      paymentMode: PaymentModeIOS.FreeTrial,
+      paymentMode: 'free-trial',
       periodCount: 7,
       period: {unit: 'day'},
       displayPrice: 'Free',

--- a/example/app/purchase-flow.tsx
+++ b/example/app/purchase-flow.tsx
@@ -92,7 +92,7 @@ export default function PurchaseFlow() {
     if (connected && !didFetchRef.current) {
       didFetchRef.current = true;
       console.log('[PurchaseFlow] Calling fetchProducts with:', PRODUCT_IDS);
-      fetchProducts({skus: PRODUCT_IDS, type: 'inapp'})
+      fetchProducts({skus: PRODUCT_IDS, type: 'in-app'})
         .then(() => {
           console.log('[PurchaseFlow] fetchProducts completed');
         })
@@ -128,7 +128,7 @@ export default function PurchaseFlow() {
           skus: [itemId],
         },
       },
-      type: 'inapp',
+      type: 'in-app',
     });
   };
 

--- a/example/app/subscription-flow.tsx
+++ b/example/app/subscription-flow.tsx
@@ -15,7 +15,6 @@ import {requestPurchase, useIAP, showManageSubscriptionsIOS} from '../../src';
 import Loading from '../src/components/Loading';
 import {SUBSCRIPTION_PRODUCT_IDS} from '../../src/utils/constants';
 import type {ProductSubscription, PurchaseIOS, Purchase} from '../../src/types';
-import {Platform as PurchasePlatform, PaymentModeIOS} from '../../src/types';
 import type {PurchaseError} from '../../src/purchase-error';
 
 /**
@@ -98,7 +97,7 @@ export default function SubscriptionFlow() {
       let isPurchased = false;
       let isRestoration = false;
 
-      if (Platform.OS === 'ios' && purchase.platform === PurchasePlatform.Ios) {
+      if (Platform.OS === 'ios' && purchase.platform === 'ios') {
         // Type-safe access to iOS-specific fields
         const iosPurchase = purchase as PurchaseIOS;
 
@@ -130,10 +129,7 @@ export default function SubscriptionFlow() {
         );
         console.log('  currentTransactionId:', purchase.id);
         console.log('  transactionReason:', iosPurchase.transactionReasonIOS);
-      } else if (
-        Platform.OS === 'android' &&
-        purchase.platform === PurchasePlatform.Android
-      ) {
+      } else if (Platform.OS === 'android' && purchase.platform === 'android') {
         // For Android, consider it purchased if we received the purchase callback
         // The purchase callback itself indicates success in most cases
         isPurchased = true;
@@ -477,15 +473,15 @@ export default function SubscriptionFlow() {
     ) {
       const offer = subscription.subscriptionInfoIOS.introductoryOffer;
       switch (offer.paymentMode) {
-        case PaymentModeIOS.FreeTrial:
+        case 'free-trial':
           return `${
             offer.periodCount
           } ${offer.period.unit.toLowerCase()}(s) free trial`;
-        case PaymentModeIOS.PayAsYouGo:
+        case 'pay-as-you-go':
           return `${offer.displayPrice} for ${
             offer.periodCount
           } ${offer.period.unit.toLowerCase()}(s)`;
-        case PaymentModeIOS.PayUpFront:
+        case 'pay-up-front':
           return `${offer.displayPrice} for first ${
             offer.periodCount
           } ${offer.period.unit.toLowerCase()}(s)`;
@@ -859,7 +855,7 @@ export default function SubscriptionFlow() {
                 </View>
                 <View style={styles.purchaseStatus}>
                   <Text style={styles.purchaseStatusText}>
-                    {purchase.platform === PurchasePlatform.Ios &&
+                    {purchase.platform === 'ios' &&
                     'expirationDateIOS' in purchase &&
                     purchase.expirationDateIOS
                       ? purchase.expirationDateIOS > Date.now()

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -111,7 +111,7 @@ describe('Public API (index.ts)', () => {
         {platform: 'ios', id: 'b'},
         {platform: 'android', id: 'a'},
       ]);
-      const res = await fetchProducts({skus: ['b', 'c'], type: 'inapp'});
+      const res = await fetchProducts({skus: ['b', 'c'], type: 'in-app'});
       expect(res).toEqual([{platform: 'ios', id: 'b'}]);
     });
 
@@ -134,7 +134,7 @@ describe('Public API (index.ts)', () => {
 
     it('fetchProducts rejects on empty skus', async () => {
       await expect(
-        fetchProducts({skus: [], type: 'inapp'}),
+        fetchProducts({skus: [], type: 'in-app'}),
       ).rejects.toMatchObject({
         code: 'EMPTY_SKU_LIST',
       } as any);
@@ -161,7 +161,7 @@ describe('Public API (index.ts)', () => {
             andDangerouslyFinishTransactionAutomatically: true,
           },
         },
-        type: 'inapp',
+        type: 'in-app',
       });
       expect(ExpoIapModule.requestPurchase).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -172,7 +172,7 @@ describe('Public API (index.ts)', () => {
       expect(res).toEqual({id: 'x'});
     });
 
-    it('maps Android inapp request properly', async () => {
+    it('maps Android in-app request properly', async () => {
       (Platform as any).OS = 'android';
       (Platform as any).select = (obj: any) => obj.android;
       (ExpoIapModule.requestPurchase as jest.Mock) = jest
@@ -180,7 +180,7 @@ describe('Public API (index.ts)', () => {
         .mockResolvedValue([]);
       await requestPurchase({
         request: {android: {skus: ['p1']}},
-        type: 'inapp',
+        type: 'in-app',
       });
       expect(ExpoIapModule.requestPurchase).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -217,14 +217,14 @@ describe('Public API (index.ts)', () => {
     it('iOS rejects when sku missing', () => {
       (Platform as any).OS = 'ios';
       expect(() =>
-        requestPurchase({request: {ios: {}} as any, type: 'inapp'} as any),
+        requestPurchase({request: {ios: {}} as any, type: 'in-app'} as any),
       ).toThrow(/sku/);
     });
 
     it('Android rejects when skus missing', () => {
       (Platform as any).OS = 'android';
       expect(() =>
-        requestPurchase({request: {android: {}} as any, type: 'inapp'} as any),
+        requestPurchase({request: {android: {}} as any, type: 'in-app'} as any),
       ).toThrow(/skus/);
     });
 
@@ -235,7 +235,7 @@ describe('Public API (index.ts)', () => {
           request: {android: {skus: ['x']}} as any,
           type: 'other' as any,
         }),
-      ).toThrow(/Invalid request for Android/);
+      ).toThrow(/Unsupported product type/);
     });
 
     it('iOS maps withOffer through offerToRecordIOS', async () => {
@@ -252,7 +252,7 @@ describe('Public API (index.ts)', () => {
         .mockResolvedValue({id: 'x'});
       await requestPurchase({
         request: {ios: {sku: 'sku1', withOffer: offer}},
-        type: 'inapp',
+        type: 'in-app',
       } as any);
       expect(ExpoIapModule.requestPurchase).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/helpers/__tests__/subscription.test.ts
+++ b/src/helpers/__tests__/subscription.test.ts
@@ -6,7 +6,6 @@ jest.mock('../../index', () => ({
 /* eslint-disable import/first */
 import {getActiveSubscriptions, hasActiveSubscriptions} from '../subscription';
 import type {Purchase} from '../../types';
-import {PurchaseState, Platform as PurchasePlatform} from '../../types';
 import {Platform as ReactNativePlatform} from 'react-native';
 import {getAvailablePurchases} from '../../index';
 /* eslint-enable import/first */
@@ -19,6 +18,10 @@ const mockPlatform = (os: 'ios' | 'android') => {
   });
 };
 
+const IOS_PLATFORM: Purchase['platform'] = 'ios';
+const ANDROID_PLATFORM: Purchase['platform'] = 'android';
+const PURCHASE_STATE_PURCHASED: Purchase['purchaseState'] = 'purchased';
+
 describe('Subscription Helper Functions', () => {
   const currentTime = Date.now();
   const oneDayMs = 24 * 60 * 60 * 1000;
@@ -28,9 +31,9 @@ describe('Subscription Helper Functions', () => {
       id: 'trans-123',
       productId: 'test.subscription',
       transactionDate: currentTime,
-      platform: PurchasePlatform.Ios,
+      platform: IOS_PLATFORM,
       isAutoRenewing: true,
-      purchaseState: PurchaseState.Purchased,
+      purchaseState: PURCHASE_STATE_PURCHASED,
       purchaseToken: 'test-token',
       quantity: 1,
       ...overrides,
@@ -59,7 +62,7 @@ describe('Subscription Helper Functions', () => {
           createPurchase({
             expirationDateIOS: currentTime + 7 * oneDayMs,
             environmentIOS: 'Production',
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -83,7 +86,7 @@ describe('Subscription Helper Functions', () => {
           createPurchase({
             transactionDate: currentTime - 10 * oneDayMs,
             expirationDateIOS: currentTime - oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -99,7 +102,7 @@ describe('Subscription Helper Functions', () => {
           createPurchase({
             transactionDate: currentTime - 12 * 60 * 60 * 1000,
             environmentIOS: 'Sandbox',
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -118,13 +121,13 @@ describe('Subscription Helper Functions', () => {
             id: 'trans-123',
             productId: 'sub1',
             expirationDateIOS: currentTime + 7 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
           createPurchase({
             id: 'trans-456',
             productId: 'sub2',
             expirationDateIOS: currentTime + 7 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -140,7 +143,7 @@ describe('Subscription Helper Functions', () => {
         const mockPurchases: Purchase[] = [
           createPurchase({
             expirationDateIOS: currentTime + 5 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -157,7 +160,7 @@ describe('Subscription Helper Functions', () => {
           createPurchase({
             purchaseToken: 'jwt-token-example',
             expirationDateIOS: currentTime + 7 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -172,7 +175,7 @@ describe('Subscription Helper Functions', () => {
         const mockPurchases: Purchase[] = [
           createPurchase({
             expirationDateIOS: currentTime + 10 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -193,7 +196,7 @@ describe('Subscription Helper Functions', () => {
       it('should return active subscriptions', async () => {
         const mockPurchases: Purchase[] = [
           createPurchase({
-            platform: PurchasePlatform.Android,
+            platform: ANDROID_PLATFORM,
             autoRenewingAndroid: true,
           }),
         ];
@@ -214,7 +217,7 @@ describe('Subscription Helper Functions', () => {
       it('should mark cancelled subscriptions as expiring soon', async () => {
         const mockPurchases: Purchase[] = [
           createPurchase({
-            platform: PurchasePlatform.Android,
+            platform: ANDROID_PLATFORM,
             autoRenewingAndroid: false,
           }),
         ];
@@ -233,13 +236,13 @@ describe('Subscription Helper Functions', () => {
           createPurchase({
             id: 'trans-123',
             productId: 'sub1',
-            platform: PurchasePlatform.Android,
+            platform: ANDROID_PLATFORM,
             autoRenewingAndroid: true,
           }),
           createPurchase({
             id: 'trans-456',
             productId: 'sub2',
-            platform: PurchasePlatform.Android,
+            platform: ANDROID_PLATFORM,
             autoRenewingAndroid: true,
           }),
         ];
@@ -259,7 +262,7 @@ describe('Subscription Helper Functions', () => {
           createPurchase({
             id: 'trans-123',
             productId: 'regular.product',
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -287,13 +290,13 @@ describe('Subscription Helper Functions', () => {
             id: 'trans-123',
             productId: 'sub1',
             expirationDateIOS: currentTime + 7 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
           createPurchase({
             id: 'trans-456',
             productId: 'sub2',
             expirationDateIOS: currentTime + 7 * oneDayMs,
-            platform: PurchasePlatform.Ios,
+            platform: IOS_PLATFORM,
           }),
         ];
 
@@ -322,7 +325,7 @@ describe('Subscription Helper Functions', () => {
           id: 'trans-123',
           productId: 'test.subscription',
           expirationDateIOS: currentTime + 7 * oneDayMs,
-          platform: PurchasePlatform.Ios,
+          platform: IOS_PLATFORM,
         }),
       ];
 
@@ -348,7 +351,7 @@ describe('Subscription Helper Functions', () => {
           id: 'trans-123',
           productId: 'sub1',
           expirationDateIOS: currentTime + 7 * oneDayMs,
-          platform: PurchasePlatform.Ios,
+          platform: IOS_PLATFORM,
         }),
       ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,25 @@ export const emitter = (ExpoIapModule || NativeModulesProxy.ExpoIap) as {
   ) => void;
 };
 
+type ProductTypeInput = 'inapp' | 'in-app' | 'subs';
+type InAppTypeInput = Exclude<ProductTypeInput, 'subs'>;
+
+const normalizeProductType = (type?: ProductTypeInput) => {
+  if (!type || type === 'inapp' || type === 'in-app') {
+    return {
+      canonical: 'in-app' as const,
+      native: 'inapp' as const,
+    };
+  }
+  if (type === 'subs') {
+    return {
+      canonical: 'subs' as const,
+      native: 'subs' as const,
+    };
+  }
+  throw new Error(`Unsupported product type: ${type}`);
+};
+
 export const purchaseUpdatedListener = (
   listener: (event: Purchase) => void,
 ) => {
@@ -146,14 +165,14 @@ export async function endConnection(): Promise<boolean> {
  *
  * @param params - Product fetch configuration
  * @param params.skus - Array of product SKUs to fetch
- * @param params.type - Type of products: 'inapp' for regular products (default) or 'subs' for subscriptions
+ * @param params.type - Type of products: 'in-app' for regular products (default) or 'subs' for subscriptions
  *
  * @example
  * ```typescript
  * // Regular products
  * const products = await fetchProducts({
  *   skus: ['product1', 'product2'],
- *   type: 'inapp'
+ *   type: 'in-app'
  * });
  *
  * // Subscriptions
@@ -165,10 +184,10 @@ export async function endConnection(): Promise<boolean> {
  */
 export const fetchProducts = async ({
   skus,
-  type = 'inapp',
+  type,
 }: {
   skus: string[];
-  type?: 'inapp' | 'subs';
+  type?: ProductTypeInput;
 }): Promise<Product[] | ProductSubscription[]> => {
   if (!skus?.length) {
     throw new PurchaseError({
@@ -177,8 +196,10 @@ export const fetchProducts = async ({
     });
   }
 
+  const {canonical, native} = normalizeProductType(type);
+
   if (Platform.OS === 'ios') {
-    const rawItems = await ExpoIapModule.fetchProducts({skus, type});
+    const rawItems = await ExpoIapModule.fetchProducts({skus, type: native});
 
     const filteredItems = rawItems.filter((item: unknown) => {
       if (!isProductIOS(item)) {
@@ -193,13 +214,13 @@ export const fetchProducts = async ({
       return isValid;
     });
 
-    return type === 'inapp'
+    return canonical === 'in-app'
       ? (filteredItems as Product[])
       : (filteredItems as ProductSubscription[]);
   }
 
   if (Platform.OS === 'android') {
-    const items = await ExpoIapModule.fetchProducts(type, skus);
+    const items = await ExpoIapModule.fetchProducts(native, skus);
     const filteredItems = items.filter((item: unknown) => {
       if (!isProductAndroid(item)) return false;
       return (
@@ -211,7 +232,7 @@ export const fetchProducts = async ({
       );
     });
 
-    return type === 'inapp'
+    return canonical === 'in-app'
       ? (filteredItems as Product[])
       : (filteredItems as ProductSubscription[]);
   }
@@ -288,7 +309,7 @@ const offerToRecordIOS = (
 type PurchaseRequest =
   | {
       request: RequestPurchaseProps;
-      type?: 'inapp';
+      type?: InAppTypeInput;
     }
   | {
       request: RequestSubscriptionPropsByPlatforms;
@@ -311,7 +332,7 @@ const normalizeRequestProps = (
  *
  * @param requestObj - Purchase request configuration
  * @param requestObj.request - Platform-specific purchase parameters
- * @param requestObj.type - Type of purchase: 'inapp' for products (default) or 'subs' for subscriptions
+ * @param requestObj.type - Type of purchase: 'in-app' for products (default) or 'subs' for subscriptions
  *
  * @example
  * ```typescript
@@ -321,7 +342,7 @@ const normalizeRequestProps = (
  *     ios: { sku: productId },
  *     android: { skus: [productId] }
  *   },
- *   type: 'inapp'
+ *   type: 'in-app'
  * });
  *
  * // Subscription purchase
@@ -340,7 +361,9 @@ const normalizeRequestProps = (
 export const requestPurchase = (
   requestObj: PurchaseRequest,
 ): Promise<Purchase | Purchase[] | void> => {
-  const {request, type = 'inapp'} = requestObj;
+  const {request, type} = requestObj;
+  const {canonical, native} = normalizeProductType(type);
+  const isInAppPurchase = canonical === 'in-app';
 
   if (Platform.OS === 'ios') {
     const normalizedRequest = normalizeRequestProps(request, 'ios');
@@ -369,7 +392,7 @@ export const requestPurchase = (
         withOffer: offer,
       });
 
-      return type === 'inapp' ? (purchase as Purchase) : (purchase as Purchase);
+      return purchase as Purchase;
     })();
   }
 
@@ -382,7 +405,7 @@ export const requestPurchase = (
       );
     }
 
-    if (type === 'inapp') {
+    if (isInAppPurchase) {
       const {
         skus,
         obfuscatedAccountIdAndroid,
@@ -392,7 +415,7 @@ export const requestPurchase = (
 
       return (async () => {
         return ExpoIapModule.requestPurchase({
-          type: 'inapp',
+          type: native,
           skuArr: skus,
           purchaseToken: undefined,
           replacementMode: -1,
@@ -404,7 +427,7 @@ export const requestPurchase = (
       })();
     }
 
-    if (type === 'subs') {
+    if (canonical === 'subs') {
       const {
         skus,
         obfuscatedAccountIdAndroid,
@@ -417,7 +440,7 @@ export const requestPurchase = (
 
       return (async () => {
         return ExpoIapModule.requestPurchase({
-          type: 'subs',
+          type: native,
           skuArr: skus,
           purchaseToken,
           replacementMode: replacementModeAndroid,

--- a/src/modules/android.ts
+++ b/src/modules/android.ts
@@ -5,19 +5,21 @@ import {Linking} from 'react-native';
 import ExpoIapModule from '../ExpoIapModule';
 
 // Types
-import type {ReceiptValidationResultAndroid, VoidResult} from '../types';
-import {Platform as PurchasePlatform} from '../types';
+import type {
+  ReceiptValidationResultAndroid,
+  VoidResult,
+  IapPlatform,
+} from '../types';
 
 // Type guards
-export function isProductAndroid<
-  T extends {platform?: string | PurchasePlatform},
->(item: unknown): item is T & {platform: PurchasePlatform.Android | 'android'} {
+export function isProductAndroid<T extends {platform?: string | IapPlatform}>(
+  item: unknown,
+): item is T & {platform: 'android'} {
   return (
     item != null &&
     typeof item === 'object' &&
     'platform' in item &&
-    ((item as any).platform === 'android' ||
-      (item as any).platform === PurchasePlatform.Android)
+    (item as any).platform === 'android'
   );
 }
 
@@ -73,7 +75,7 @@ export const deepLinkToSubscriptionsAndroid = async ({
  * @param {string} params.productId - product id for your in app product.
  * @param {string} params.productToken - token for your purchase (called 'token' in the API documentation).
  * @param {string} params.accessToken - OAuth access token with androidpublisher scope. Required for authentication.
- * @param {boolean} params.isSub - whether this is subscription or inapp. `true` for subscription.
+ * @param {boolean} params.isSub - whether this is subscription or in-app. `true` for subscription.
  * @returns {Promise<ReceiptAndroid>}
  */
 export const validateReceiptAndroid = async ({

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -11,9 +11,9 @@ import type {
   SubscriptionStatusIOS,
   AppTransaction,
   ReceiptValidationResultIOS,
+  IapPlatform,
 } from '../types';
 import type {PurchaseError} from '../purchase-error';
-import {Platform as PurchasePlatform} from '../types';
 import {Linking} from 'react-native';
 
 export type TransactionEvent = {
@@ -24,15 +24,14 @@ export type TransactionEvent = {
 // Listeners
 
 // Type guards
-export function isProductIOS<T extends {platform?: string | PurchasePlatform}>(
+export function isProductIOS<T extends {platform?: string | IapPlatform}>(
   item: unknown,
-): item is T & {platform: PurchasePlatform.Ios | 'ios'} {
+): item is T & {platform: 'ios'} {
   return (
     item != null &&
     typeof item === 'object' &&
     'platform' in item &&
-    ((item as any).platform === 'ios' ||
-      (item as any).platform === PurchasePlatform.Ios)
+    (item as any).platform === 'ios'
   );
 }
 

--- a/src/purchase-error.ts
+++ b/src/purchase-error.ts
@@ -1,8 +1,14 @@
 import {NATIVE_ERROR_CODES} from './ExpoIapModule';
-import {ErrorCode, Platform} from './types';
+import {ErrorCode} from './types';
+import type {IapPlatform} from './types';
 
 /** Platform identifiers supported by {@link PurchaseError}. */
-export type PurchaseErrorPlatform = Platform | 'ios' | 'android';
+export type PurchaseErrorPlatform =
+  | IapPlatform
+  | 'IOS'
+  | 'ANDROID'
+  | 'ios'
+  | 'android';
 
 /** Properties used to construct a {@link PurchaseError}. */
 export interface PurchaseErrorProps {
@@ -29,7 +35,9 @@ const toStandardizedCode = (errorCode: ErrorCode): string =>
 const normalizePlatform = (
   platform: PurchaseErrorPlatform,
 ): 'ios' | 'android' =>
-  platform === Platform.Ios || platform === 'ios' ? 'ios' : 'android';
+  typeof platform === 'string' && platform.toLowerCase() === 'ios'
+    ? 'ios'
+    : 'android';
 
 const OPENIAP_ERROR_CODE_SET: Set<string> = new Set(
   Object.values(ErrorCode).map((code) => toStandardizedCode(code)),

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,11 +131,12 @@ export interface FetchProductsResult {
   subscriptions?: ProductSubscription[] | null;
 }
 
-export enum IapEvent {
-  PromotedProductIos = 'PROMOTED_PRODUCT_IOS',
-  PurchaseError = 'PURCHASE_ERROR',
-  PurchaseUpdated = 'PURCHASE_UPDATED',
-}
+export type IapEvent =
+  | 'promoted-product-ios'
+  | 'purchase-error'
+  | 'purchase-updated';
+
+export type IapPlatform = 'android' | 'ios';
 
 export interface Mutation {
   /** Acknowledge a non-consumable purchase or subscription */
@@ -199,17 +200,11 @@ export interface MutationValidateReceiptArgs {
   options: ReceiptValidationProps;
 }
 
-export enum PaymentModeIOS {
-  Empty = 'EMPTY',
-  FreeTrial = 'FREE_TRIAL',
-  PayAsYouGo = 'PAY_AS_YOU_GO',
-  PayUpFront = 'PAY_UP_FRONT',
-}
-
-export enum Platform {
-  Android = 'ANDROID',
-  Ios = 'IOS',
-}
+export type PaymentModeIOS =
+  | 'empty'
+  | 'free-trial'
+  | 'pay-as-you-go'
+  | 'pay-up-front';
 
 export interface PricingPhaseAndroid {
   billingCycleCount: number;
@@ -235,7 +230,7 @@ export interface ProductAndroid extends ProductCommon {
   id: string;
   nameAndroid: string;
   oneTimePurchaseOfferDetailsAndroid?: ProductAndroidOneTimePurchaseOfferDetail | null;
-  platform: Platform;
+  platform: IapPlatform;
   price?: number | null;
   subscriptionOfferDetailsAndroid?:
     | ProductSubscriptionAndroidOfferDetails[]
@@ -257,7 +252,7 @@ export interface ProductCommon {
   displayName?: string | null;
   displayPrice: string;
   id: string;
-  platform: Platform;
+  platform: IapPlatform;
   price?: number | null;
   title: string;
   type: ProductType;
@@ -273,7 +268,7 @@ export interface ProductIOS extends ProductCommon {
   id: string;
   isFamilyShareableIOS: boolean;
   jsonRepresentationIOS: string;
-  platform: Platform;
+  platform: IapPlatform;
   price?: number | null;
   subscriptionInfoIOS?: SubscriptionInfoIOS | null;
   title: string;
@@ -281,11 +276,7 @@ export interface ProductIOS extends ProductCommon {
   typeIOS: ProductTypeIOS;
 }
 
-export enum ProductQueryType {
-  All = 'ALL',
-  InApp = 'IN_APP',
-  Subs = 'SUBS',
-}
+export type ProductQueryType = 'all' | 'in-app' | 'subs';
 
 export interface ProductRequest {
   skus: string[];
@@ -305,7 +296,7 @@ export interface ProductSubscriptionAndroid extends ProductCommon {
   id: string;
   nameAndroid: string;
   oneTimePurchaseOfferDetailsAndroid?: ProductAndroidOneTimePurchaseOfferDetail | null;
-  platform: Platform;
+  platform: IapPlatform;
   price?: number | null;
   subscriptionOfferDetailsAndroid: ProductSubscriptionAndroidOfferDetails[];
   title: string;
@@ -336,7 +327,7 @@ export interface ProductSubscriptionIOS extends ProductCommon {
   introductoryPriceSubscriptionPeriodIOS?: SubscriptionPeriodIOS | null;
   isFamilyShareableIOS: boolean;
   jsonRepresentationIOS: string;
-  platform: Platform;
+  platform: IapPlatform;
   price?: number | null;
   subscriptionInfoIOS?: SubscriptionInfoIOS | null;
   subscriptionPeriodNumberIOS?: string | null;
@@ -346,17 +337,13 @@ export interface ProductSubscriptionIOS extends ProductCommon {
   typeIOS: ProductTypeIOS;
 }
 
-export enum ProductType {
-  InApp = 'IN_APP',
-  Subs = 'SUBS',
-}
+export type ProductType = 'in-app' | 'subs';
 
-export enum ProductTypeIOS {
-  AutoRenewableSubscription = 'AUTO_RENEWABLE_SUBSCRIPTION',
-  Consumable = 'CONSUMABLE',
-  NonConsumable = 'NON_CONSUMABLE',
-  NonRenewingSubscription = 'NON_RENEWING_SUBSCRIPTION',
-}
+export type ProductTypeIOS =
+  | 'auto-renewable-subscription'
+  | 'consumable'
+  | 'non-consumable'
+  | 'non-renewing-subscription';
 
 export type Purchase = PurchaseAndroid | PurchaseIOS;
 
@@ -371,7 +358,7 @@ export interface PurchaseAndroid extends PurchaseCommon {
   obfuscatedAccountIdAndroid?: string | null;
   obfuscatedProfileIdAndroid?: string | null;
   packageNameAndroid?: string | null;
-  platform: Platform;
+  platform: IapPlatform;
   productId: string;
   purchaseState: PurchaseState;
   purchaseToken?: string | null;
@@ -384,7 +371,7 @@ export interface PurchaseCommon {
   id: string;
   ids?: string[] | null;
   isAutoRenewing: boolean;
-  platform: Platform;
+  platform: IapPlatform;
   productId: string;
   purchaseState: PurchaseState;
   /** Unified purchase token (iOS JWS, Android purchaseToken) */
@@ -415,7 +402,7 @@ export interface PurchaseIOS extends PurchaseCommon {
   originalTransactionDateIOS?: number | null;
   originalTransactionIdentifierIOS?: string | null;
   ownershipTypeIOS?: string | null;
-  platform: Platform;
+  platform: IapPlatform;
   productId: string;
   purchaseState: PurchaseState;
   purchaseToken?: string | null;
@@ -436,7 +423,7 @@ export interface PurchaseInput {
   id: string;
   ids?: string[] | null;
   isAutoRenewing: boolean;
-  platform: Platform;
+  platform: IapPlatform;
   productId: string;
   purchaseState: PurchaseState;
   purchaseToken?: string | null;
@@ -466,14 +453,13 @@ export interface PurchaseParams {
   type?: ProductQueryType | null;
 }
 
-export enum PurchaseState {
-  Deferred = 'DEFERRED',
-  Failed = 'FAILED',
-  Pending = 'PENDING',
-  Purchased = 'PURCHASED',
-  Restored = 'RESTORED',
-  Unknown = 'UNKNOWN',
-}
+export type PurchaseState =
+  | 'deferred'
+  | 'failed'
+  | 'pending'
+  | 'purchased'
+  | 'restored'
+  | 'unknown';
 
 export interface Query {
   /** Get current StoreKit 2 entitlements (iOS 15+) */
@@ -710,18 +696,9 @@ export interface SubscriptionOfferIOS {
   type: SubscriptionOfferTypeIOS;
 }
 
-export enum SubscriptionOfferTypeIOS {
-  Introductory = 'INTRODUCTORY',
-  Promotional = 'PROMOTIONAL',
-}
+export type SubscriptionOfferTypeIOS = 'introductory' | 'promotional';
 
-export enum SubscriptionPeriodIOS {
-  Day = 'DAY',
-  Empty = 'EMPTY',
-  Month = 'MONTH',
-  Week = 'WEEK',
-  Year = 'YEAR',
-}
+export type SubscriptionPeriodIOS = 'day' | 'empty' | 'month' | 'week' | 'year';
 
 export interface SubscriptionPeriodValueIOS {
   unit: SubscriptionPeriodIOS;

--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -69,12 +69,12 @@ type UseIap = {
   getAvailablePurchases: () => Promise<void>;
   fetchProducts: (params: {
     skus: string[];
-    type?: 'inapp' | 'subs';
+    type?: 'in-app' | 'inapp' | 'subs';
   }) => Promise<void>;
 
   requestPurchase: (params: {
     request: RequestPurchaseProps | RequestSubscriptionPropsByPlatforms;
-    type?: 'inapp' | 'subs';
+    type?: 'in-app' | 'inapp' | 'subs';
   }) => Promise<any>;
   validateReceipt: (
     sku: string,
@@ -194,7 +194,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   const fetchProductsInternal = useCallback(
     async (params: {
       skus: string[];
-      type?: 'inapp' | 'subs';
+      type?: 'in-app' | 'inapp' | 'subs';
     }): Promise<void> => {
       try {
         const result = await fetchProducts(params);
@@ -293,7 +293,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   );
 
   const requestPurchaseWithReset = useCallback(
-    async (requestObj: {request: any; type?: 'inapp' | 'subs'}) => {
+    async (requestObj: {request: any; type?: 'in-app' | 'inapp' | 'subs'}) => {
       clearCurrentPurchase();
       clearCurrentPurchaseError();
 


### PR DESCRIPTION
Align OpenIAP literal unions across generated types and runtime helpers to match the updated schema. Refresh docs, examples, and tests so consumers see the lowercase literals while preserving native compatibility.

Validated with  and .