### PR TITLE
refactor(useiap)!: remove transient purchase tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # Implementation Guidelines
 
+## Commit Message Convention
+
+- Follow the Angular Conventional Commits format: `<type>(<scope>): <subject>`
+- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+- Scope is optional but recommended (for example: `auth`, `api`, `ui`)
+- Subject must be imperative, lowercase, without a trailing period, and roughly 50 characters
+- Wrap commit body lines near 72 characters and include footers such as `BREAKING CHANGE:` or `Closes #123` when needed
+
 ## Expo-Specific Guidelines
 
 ### iOS Pod Configuration


### PR DESCRIPTION
## Summary
- remove currentPurchase/currentPurchaseError state in favor of the onPurchaseSuccess/onPurchaseError callbacks handling purchase results
- strip the duplicate success guard and console logging while keeping subscription refresh logic intact
- document the Angular conventional commit requirement in CLAUDE.md for future contributors

## Testing
- bun run lint
- bun run typecheck *(fails: Script not found "typecheck")*
- bun run test
- cd example && bun run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional flag to auto-sync purchases.
- Bug Fixes
  - Prevented duplicate products/subscriptions in listings.
  - Improved reliability of purchase updates and error handling.
- Refactor
  - Simplified purchase flow and reduced noisy logs.
  - Removed exposed purchase state fields and clear methods from the public API (breaking change).
- Documentation
  - Added “Commit Message Convention” guidelines using Angular Conventional Commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->