### PR TITLE
Remove legacy getProducts/getSubscriptions references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ The library follows the OpenIAP type specifications with platform-specific exten
 ### Hook API Semantics (useIAP)
 
 - Inside the `useIAP` hook, most methods return `Promise<void>` and update internal state. Do not design examples or implementations that expect data from these methods.
-  - Examples: `fetchProducts`, `requestProducts`, `getProducts`/`getSubscriptions` (deprecated helpers), `requestPurchase`, `getAvailablePurchases`.
+  - Examples: `fetchProducts`, `requestPurchase`, `getAvailablePurchases`.
   - After calling, consume state from the hook: `products`, `subscriptions`, `availablePurchases`, etc.
 - Defined exceptions that DO return values in the hook:
   - `getActiveSubscriptions(subscriptionIds?) => Promise<ActiveSubscription[]>` (also updates `activeSubscriptions` state)
@@ -102,7 +102,7 @@ The library follows the OpenIAP type specifications with platform-specific exten
 
 ### API Method Naming
 
-- Functions that depend on event results should use `request` prefix (e.g., `requestPurchase`, `requestSubscription`)
+- Functions that depend on event results should use `request` prefix (e.g., `requestPurchase`)
 - Follow OpenIAP terminology: <https://www.openiap.dev/docs/apis#terminology>
 - Do not use generic prefixes like `get`, `find` - refer to the official terminology
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -79,7 +79,7 @@ export interface Platform {
 
 ```typescript
 // ✅ Good - Clear parameter and return types
-export const requestProducts = async (params: {
+export const fetchProducts = async (params: {
   skus: string[];
   type?: 'in-app' | 'subs';
 }): Promise<Product[]> => {
@@ -87,7 +87,7 @@ export const requestProducts = async (params: {
 };
 
 // ❌ Bad - Missing types
-export const requestProducts = async (params) => {
+export const fetchProducts = async (params) => {
   // implementation
 };
 
@@ -161,7 +161,7 @@ export const deepLinkToSubscriptionsAndroid = async ({
 
 ```typescript
 // These functions handle platform differences internally
-export const requestProducts = async (params: {
+export const fetchProducts = async (params: {
   skus: string[];
   type?: 'in-app' | 'subs';
 }): Promise<Product[]> => {
@@ -294,12 +294,12 @@ Always use async/await over promises:
 
 ```typescript
 // ✅ Good
-export const requestProducts = async (params: {
+export const fetchProducts = async (params: {
   skus: string[];
   type?: 'in-app' | 'subs';
 }): Promise<Product[]> => {
   try {
-    const products = await ExpoIapModule.requestProducts(params);
+    const products = await ExpoIapModule.fetchProducts(params);
     return products;
   } catch (error) {
     console.error('Failed to get products:', error);
@@ -308,8 +308,8 @@ export const requestProducts = async (params: {
 };
 
 // ❌ Bad
-export const requestProducts = (params): Promise<Product[]> => {
-  return ExpoIapModule.requestProducts(params)
+export const fetchProducts = (params): Promise<Product[]> => {
+  return ExpoIapModule.fetchProducts(params)
     .then((products) => products)
     .catch((error) => {
       console.error('Failed to get products:', error);
@@ -334,12 +334,12 @@ All public APIs must have JSDoc comments:
  *
  * @example
  * ```typescript
- * const products = await requestProducts({ skus: ['com.example.premium'], type: 'in-app' });
+ * const products = await fetchProducts({ skus: ['com.example.premium'], type: 'in-app' });
  * ```
  *
  * @platform iOS
  */
-export const requestProductsIOS = async (params: {
+export const fetchProductsIOS = async (params: {
   skus: string[];
   type?: 'in-app' | 'subs';
 }): Promise<ProductIOS[]> => {
@@ -357,7 +357,7 @@ export const requestProductsIOS = async (params: {
 ### Hook vs Root API Semantics
 
 - useIAP (hook) methods are designed for React state flows and generally return `Promise<void>` while updating internal state. Do not expect data from these methods.
-  - Examples: `fetchProducts`, `requestProducts`, `getProducts` (deprecated helper), `getSubscriptions` (deprecated helper), `requestPurchase`, `getAvailablePurchases`.
+  - Examples: `fetchProducts`, `requestPurchase`, `getAvailablePurchases`.
   - Pattern: call the method, then read from hook state such as `products`, `subscriptions`, `availablePurchases`.
 - Exceptions in the hook API:
   - `getActiveSubscriptions(subscriptionIds?) => Promise<ActiveSubscription[]>` returns computed subscription info and also updates `activeSubscriptions` state.
@@ -378,7 +378,7 @@ describe('PurchaseManager', () => {
     });
 
     it('should get products on iOS', async () => {
-      const products = await requestProductsIOS({
+      const products = await fetchProductsIOS({
         skus: ['com.example.product'],
         type: 'in-app',
       });
@@ -393,7 +393,7 @@ describe('PurchaseManager', () => {
 
     it('should throw error on Android', async () => {
       await expect(
-        requestProductsIOS({skus: ['com.example.product'], type: 'in-app'}),
+        fetchProductsIOS({skus: ['com.example.product'], type: 'in-app'}),
       ).rejects.toThrow('This method is only available on iOS');
     });
   });
@@ -547,8 +547,8 @@ await requestPurchase({
   type: 'subs',
 });
 
-// ❌ Bad - Using deprecated requestSubscription
-await requestSubscription({
+// ❌ Bad - Using deprecated requestPurchase
+await requestPurchase({
   sku: subscriptionId,
   skus: [subscriptionId],
 });

--- a/docs/docs/api/methods/core-methods.md
+++ b/docs/docs/api/methods/core-methods.md
@@ -776,6 +776,3 @@ This ensures pending transactions are surfaced and properly resolved without a s
 ## Removed APIs
 
 - `requestProducts()` — Removed in v3.0.0. Use `fetchProducts({ skus, type })` instead.
-- `getProducts()` — Removed in v3.0.0. Use `fetchProducts({ skus, type: 'in-app' })` instead.
-- `getSubscriptions()` — Removed in v3.0.0. Use `fetchProducts({ skus, type: 'subs' })` instead.
-- `requestSubscription()` — Removed in v3.0.0. Use `requestPurchase({ ..., type: 'subs' })` and supply Android `subscriptionOffers`.

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -145,7 +145,7 @@ The helper `getActiveSubscriptions` in `src/helpers/subscription.ts` converts `P
 The request types have been harmonised to match the schema definitions.
 
 ```ts
-export interface RequestPurchaseProps {
+export interface RequestPurchasePropsByPlatforms {
   android?: RequestPurchaseAndroidProps | null;
   ios?: RequestPurchaseIosProps | null;
 }
@@ -155,11 +155,15 @@ export interface RequestSubscriptionPropsByPlatforms {
   ios?: RequestSubscriptionIosProps | null;
 }
 
-export interface RequestPurchaseParams {
-  requestPurchase?: RequestPurchasePropsByPlatforms | null;
-  requestSubscription?: RequestSubscriptionPropsByPlatforms | null;
-  type?: ProductQueryType | null;
-}
+export type MutationRequestPurchaseArgs =
+  | {
+      request: RequestPurchasePropsByPlatforms;
+      type: 'in-app';
+    }
+  | {
+      request: RequestSubscriptionPropsByPlatforms;
+      type: 'subs';
+    };
 ```
 
 ## Receipt Validation

--- a/docs/docs/examples/subscription-flow.md
+++ b/docs/docs/examples/subscription-flow.md
@@ -81,7 +81,7 @@ export default function SubscriptionManager() {
     subscriptions,
     currentPurchase,
     currentPurchaseError,
-    requestProducts,
+    fetchProducts,
     getAvailablePurchases,
     requestPurchase,
     finishTransaction,

--- a/docs/docs/getting-started/setup-android.md
+++ b/docs/docs/getting-started/setup-android.md
@@ -37,7 +37,7 @@ const androidProductIds = [
 ];
 
 function App() {
-  const {connected, products, subscriptions, requestProducts, requestPurchase} =
+  const {connected, products, subscriptions, fetchProducts, requestPurchase} =
     useIAP({
       onPurchaseSuccess: (purchase) => {
         console.log('Purchase successful:', purchase);

--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -97,7 +97,7 @@ Common causes:
 5. **Store setup incomplete** - see platform-specific requirements below
 
 ```tsx
-const {connected, requestProducts} = useIAP();
+const {connected, fetchProducts} = useIAP();
 
 useEffect(() => {
   if (connected) {
@@ -360,7 +360,7 @@ When using the `useIAP` hook:
 
 - Products are automatically cached by the native StoreKit (iOS) and Google Play Billing (Android) modules
 - The hook maintains state of fetched products in the `products` and `subscriptions` arrays
-- Simply call `requestProducts` when needed - the library handles caching efficiently
+- Simply call `fetchProducts` when needed - the library handles caching efficiently
 
 ```tsx
 // No manual caching needed - just fetch when connected
@@ -420,7 +420,7 @@ const {
   connected,
   products,
   purchases,
-  requestProducts, // Updated method name
+  fetchProducts, // Updated method name
   requestPurchase,
   finishTransaction,
   // ... other methods

--- a/docs/docs/guides/ios-subscription-offers.md
+++ b/docs/docs/guides/ios-subscription-offers.md
@@ -54,7 +54,7 @@ type SubscriptionOffer = {
 ### With expo-iap v2.6.0+
 
 ```typescript
-import {requestProducts} from 'expo-iap';
+import {fetchProducts} from 'expo-iap';
 
 const subscriptions = await fetchProducts({
   skus: ['com.example.premium'],

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -43,7 +43,7 @@ When you use the `useIAP` hook, it automatically:
 import {useIAP} from 'expo-iap';
 
 export default function App() {
-  const {connected, products, requestProducts} = useIAP();
+  const {connected, products, fetchProducts} = useIAP();
 
   useEffect(() => {
     // Connection is automatically established
@@ -52,7 +52,7 @@ export default function App() {
       // You can now safely call store methods
       fetchProducts({skus: ['product1', 'product2'], type: 'in-app'});
     }
-  }, [connected, requestProducts]);
+  }, [connected, fetchProducts]);
 
   return <YourAppContent />;
 }
@@ -223,7 +223,7 @@ export default function StoreComponent() {
 ```tsx
 // ✅ Good: Using useIAP hook
 function MyApp() {
-  const {connected, products, requestProducts} = useIAP();
+  const {connected, products, fetchProducts} = useIAP();
 
   useEffect(() => {
     if (connected) {

--- a/docs/docs/guides/migration.md
+++ b/docs/docs/guides/migration.md
@@ -16,8 +16,8 @@ This guide helps you migrate from `react-native-iap` to `expo-iap`. While the AP
 
 v3 unifies tokens and removes legacy helpers to simplify the surface.
 
-- Removed functions: `getProducts`, `getSubscriptions`, `requestProducts`, `requestSubscription`, `getPurchaseHistory` / `getPurchaseHistories`, and non‑suffixed iOS aliases
-- Use `fetchProducts({ skus, type })` and `requestPurchase({ request, type })`
+- Legacy product/subscription listing helpers were removed; use `fetchProducts({ skus, type })` for both purchases and subscriptions.
+- Prefer `fetchProducts({ skus, type })` alongside `requestPurchase({ request, type })`
 - `showManageSubscriptionsIOS(): Promise<Purchase[]>` now returns purchases
 - `getAvailablePurchases` options are iOS‑only: `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`
 - Tokens: Use `purchase.purchaseToken` for both platforms
@@ -25,10 +25,9 @@ v3 unifies tokens and removes legacy helpers to simplify the surface.
 Quick mappings:
 
 ```ts
-// getProducts/getSubscriptions/requestProducts → fetchProducts
+// Legacy product/subscription helpers → fetchProducts
 await fetchProducts({skus: ['id1', 'id2'], type: 'in-app'});
 
-// requestSubscription → requestPurchase with subs
 await requestPurchase({
   request: {
     ios: {sku: 'sub_monthly'},
@@ -72,7 +71,7 @@ import {useIAP, withIAPContext} from 'react-native-iap';
 const AppWithIAP = withIAPContext(App);
 
 function App() {
-  const {connected, products, getProducts} = useIAP();
+  const {connected, products, fetchProducts} = useIAP();
   // ...
 }
 ```
@@ -84,7 +83,7 @@ import {useIAP} from 'expo-iap';
 
 // No context wrapper needed
 function App() {
-  const {connected, products, getProducts} = useIAP();
+  const {connected, products, fetchProducts} = useIAP();
   // Connection and listeners are automatically managed
 }
 ```
@@ -138,7 +137,7 @@ Replace all react-native-iap imports:
 // Before
 import {
   initConnection,
-  getProducts,
+  fetchProducts,
   requestPurchase,
   useIAP,
   withIAPContext,
@@ -147,7 +146,7 @@ import {
 // After
 import {
   initConnection,
-  getProducts,
+  fetchProducts,
   requestPurchase,
   useIAP,
   // withIAPContext not needed
@@ -195,8 +194,8 @@ const {
   currentPurchase,
   currentPurchaseError,
   finishTransaction,
-  getProducts,
-  getSubscriptions,
+  fetchProducts,
+  fetchProducts,
 } = useIAP();
 ```
 
@@ -212,8 +211,8 @@ const {
   currentPurchase,
   currentPurchaseError,
   finishTransaction,
-  getProducts,
-  getSubscriptions,
+  fetchProducts,
+  fetchProducts,
   getPurchaseHistories, // Method: plural form in expo-iap v2.6.0+
   getAvailablePurchases,
   // Additional methods and better typing
@@ -319,11 +318,11 @@ purchaseUpdatedListener((purchase) => {
 
 **fetchProducts() Introduction**
 
-`fetchProducts()` replaces `requestProducts()`:
+`fetchProducts()` replaces `fetchProducts()`:
 
 ```tsx
 // ❌ Old (deprecated in v2.8.7)
-const products = await requestProducts({skus: ['product1'], type: 'in-app'});
+const products = await fetchProducts({skus: ['product1'], type: 'in-app'});
 
 // ✅ New (v2.8.7+)
 const products = await fetchProducts({skus: ['product1'], type: 'in-app'});
@@ -362,26 +361,9 @@ await getPurchaseHistories(); // Note: plural form in expo-iap v2.6.0+
 
 ### Deprecated Methods in expo-iap
 
-> **⚠️ Important:** The following methods are deprecated and will be removed in a future version:
-
-| Deprecated Method        | Replacement                               |
-| ------------------------ | ----------------------------------------- |
-| `getProducts(skus)`      | `fetchProducts({ skus, type: 'in-app' })` |
-| `getSubscriptions(skus)` | `fetchProducts({ skus, type: 'subs' })`   |
-
-**Migration Examples:**
+> **⚠️ Important:** Dedicated product/subscription request helpers have been removed. Always call `fetchProducts({ skus, type })` for both consumables and subscriptions.
 
 ```tsx
-// Old way (deprecated)
-import {getProducts, getSubscriptions} from 'expo-iap';
-
-const products = await fetchProducts({
-  skus: ['product1', 'product2'],
-  type: 'in-app',
-});
-const subs = await fetchProducts({skus: ['sub1', 'sub2'], type: 'subs'});
-
-// New way (recommended)
 import {fetchProducts} from 'expo-iap';
 
 const products = await fetchProducts({
@@ -389,7 +371,10 @@ const products = await fetchProducts({
   type: 'in-app',
 });
 
-const subs = await fetchProducts({skus: ['sub1', 'sub2'], type: 'subs'});
+const subscriptions = await fetchProducts({
+  skus: ['sub1', 'sub2'],
+  type: 'subs',
+});
 ```
 
 ### New Methods
@@ -423,7 +408,7 @@ Create a simple test to ensure basic functionality works:
 import {useIAP} from 'expo-iap';
 
 export default function MigrationTest() {
-  const {connected, getProducts} = useIAP();
+  const {connected, fetchProducts} = useIAP();
 
   useEffect(() => {
     if (connected) {
@@ -437,7 +422,7 @@ export default function MigrationTest() {
           console.error('❌ Product fetch failed:', error);
         });
     }
-  }, [connected, getProducts]);
+  }, [connected, fetchProducts]);
 
   return (
     <View>

--- a/docs/docs/guides/purchases.md
+++ b/docs/docs/guides/purchases.md
@@ -164,7 +164,7 @@ export default function PurchaseScreen() {
     subscriptions,
     currentPurchase,
     currentPurchaseError,
-    requestProducts,
+    fetchProducts,
     requestPurchase,
     finishTransaction,
     validateReceipt,
@@ -189,7 +189,7 @@ export default function PurchaseScreen() {
     };
 
     initializeIAP();
-  }, [connected, requestProducts]);
+  }, [connected, fetchProducts]);
 
   // Validate receipt helper
   const handleValidateReceipt = useCallback(

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -39,11 +39,11 @@ This is one of the most common issues. Here are the potential causes and solutio
 #### 1. Connection not established
 
 ```tsx
-const {connected, getProducts} = useIAP();
+const {connected, fetchProducts} = useIAP();
 
 useEffect(() => {
   if (connected) {
-    // ✅ Only call requestProducts when connected
+    // ✅ Only call fetchProducts when connected
     fetchProducts({skus: productIds, type: 'in-app'});
   } else {
     console.log('Not connected to store yet');

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -53,7 +53,7 @@ function MyStore() {
   const {
     connected,
     products,
-    requestProducts,
+    fetchProducts,
     requestPurchase,
     currentPurchase,
     finishTransaction,

--- a/example/__tests__/core-functions.test.tsx
+++ b/example/__tests__/core-functions.test.tsx
@@ -17,7 +17,7 @@ describe('Core Functions Tests', () => {
       expect(typeof ExpoIap.fetchProducts).toBe('function');
     });
 
-    // v3: legacy helpers removed (requestProducts/getProducts/getSubscriptions)
+    // v3: legacy helpers removed
 
     it('should export requestPurchase function', () => {
       expect(ExpoIap.requestPurchase).toBeDefined();

--- a/example/app/subscription-flow.tsx
+++ b/example/app/subscription-flow.tsx
@@ -314,7 +314,7 @@ export default function SubscriptionFlow() {
     if (connected && !didFetchSubsRef.current) {
       didFetchSubsRef.current = true;
       console.log('Connected to store, loading subscription products...');
-      // requestProducts is event-based, not promise-based
+      // fetchProducts populates hook state; results surface via subscriptions state
       // Results will be available through the useIAP hook's subscriptions state
       fetchProducts({skus: subscriptionIds, type: 'subs'});
       console.log('Product loading request sent - waiting for results...');

--- a/src/__mocks__/expo-modules-core.js
+++ b/src/__mocks__/expo-modules-core.js
@@ -20,7 +20,6 @@ module.exports = {
     clearTransactionIOS: jest.fn(),
     // Common methods
     fetchProducts: jest.fn(),
-    requestProducts: jest.fn(),
     requestPurchase: jest.fn(),
     requestPurchaseOnPromotedProductIOS: jest.fn(),
     // Android-specific methods

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -139,8 +139,6 @@ describe('Public API (index.ts)', () => {
       expect(res).toEqual([{platform: 'android', id: 'sub2'}]);
     });
 
-    // Removed legacy getProducts/getSubscriptions in v3.0.0
-
     it('fetchProducts rejects on empty skus', async () => {
       await expect(
         fetchProducts({skus: [], type: 'in-app'}),
@@ -331,38 +329,6 @@ describe('Public API (index.ts)', () => {
   });
 
   describe('legacy wrappers and getters', () => {
-    it('getProducts and getSubscriptions delegate and filter', async () => {
-      (Platform as any).OS = 'android';
-      (ExpoIapModule.fetchProducts as jest.Mock) = jest.fn().mockResolvedValue([
-        {platform: 'android', id: 'a'},
-        {platform: 'android', id: 'b'},
-      ]);
-      expect(true).toBe(true);
-
-      (Platform as any).OS = 'ios';
-      (Platform as any).select = (obj: any) => obj.ios;
-      (ExpoIapModule.fetchProducts as jest.Mock) = jest.fn().mockResolvedValue([
-        {platform: 'ios', id: 's1'},
-        {platform: 'ios', id: 's2'},
-      ]);
-      expect(true).toBe(true);
-    });
-
-    it('requestProducts placeholder (removed in v3)', async () => {
-      // Removed legacy API in v3; keeping placeholder to maintain suite structure
-      expect(true).toBe(true);
-    });
-
-    it('requestSubscription warns and calls purchase with subs', async () => {
-      (Platform as any).OS = 'android';
-      (ExpoIapModule.requestPurchase as jest.Mock) = jest
-        .fn()
-        .mockResolvedValue([]);
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      expect(true).toBe(true);
-      warnSpy.mockRestore();
-    });
-
     it('getAvailablePurchases: iOS and Android paths', async () => {
       // iOS path
       (Platform as any).OS = 'ios';

--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -187,25 +187,6 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [],
   );
 
-  const getSubscriptionsInternal = useCallback(
-    async (skus: string[]): Promise<void> => {
-      try {
-        const result = await fetchProducts({skus, type: 'subs'});
-        const subscriptionsResult = (result ?? []) as ProductSubscription[];
-        setSubscriptions((prevSubscriptions) =>
-          mergeWithDuplicateCheck(
-            prevSubscriptions,
-            subscriptionsResult,
-            (subscription) => subscription.id,
-          ),
-        );
-      } catch (error) {
-        console.error('Error fetching subscriptions:', error);
-      }
-    },
-    [mergeWithDuplicateCheck],
-  );
-
   const fetchProductsInternal = useCallback(
     async (params: {
       skus: string[];
@@ -330,14 +311,14 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     async (productId: string) => {
       try {
         if (subscriptionsRefState.current.some((sub) => sub.id === productId)) {
-          await getSubscriptionsInternal([productId]);
+          await fetchProductsInternal({skus: [productId], type: 'subs'});
           await getAvailablePurchasesInternal();
         }
       } catch (error) {
         console.warn('Failed to refresh subscription status:', error);
       }
     },
-    [getAvailablePurchasesInternal, getSubscriptionsInternal],
+    [fetchProductsInternal, getAvailablePurchasesInternal],
   );
 
   // Restore completed transactions with cross-platform behavior.


### PR DESCRIPTION
## Summary
Remove remaining code and docs that referenced the old getProducts/getSubscriptions helpers so the package consistently uses fetchProducts.
Ensure the hook refresh path reuses fetchProducts while tidying mocks, examples, and guidance accordingly.
