### PR TITLE
fix: iOS subscription cleanup and remove onSyncError callback

### DIFF
--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -48,9 +48,6 @@ const {
   onPurchaseError: (error) => {
     console.error('Purchase failed:', error);
   },
-  onSyncError: (error) => {
-    console.warn('Sync error:', error);
-  },
 });
 ```
 
@@ -68,7 +65,6 @@ const {
 interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
   shouldAutoSyncPurchases?: boolean; // Controls auto sync behavior inside the hook
   onPromotedProductIOS?: (product: Product) => void; // iOS promoted products
 }
@@ -100,18 +96,6 @@ interface UseIAPOptions {
     if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
-  };
-  ```
-
-#### onSyncError
-
-- **Type**: `(error: Error) => void`
-- **Description**: Called when there's an error syncing with the store
-- **Example**:
-
-  ```tsx
-  onSyncError: (error) => {
-    console.warn('Store sync error:', error.message);
   };
   ```
 

--- a/example/app/purchase-flow.tsx
+++ b/example/app/purchase-flow.tsx
@@ -572,10 +572,6 @@ function PurchaseFlowContainer() {
       setIsProcessing(false);
       setPurchaseResult(`Purchase failed: ${error.message}`);
     },
-    onSyncError: (error: Error) => {
-      console.warn('Sync error:', error);
-      Alert.alert('Sync Error', `Failed to sync purchases: ${error.message}`);
-    },
   });
 
   const didFetchRef = useRef(false);

--- a/example/app/subscription-flow.tsx
+++ b/example/app/subscription-flow.tsx
@@ -768,13 +768,6 @@ function SubscriptionFlowContainer() {
       resetHandlingState();
       setPurchaseResult(`Subscription failed: ${error.message}`);
     },
-    onSyncError: (error: Error) => {
-      console.warn('Sync error:', error);
-      Alert.alert(
-        'Sync Error',
-        `Failed to sync subscriptions: ${error.message}`,
-      );
-    },
   });
 
   const handleRefreshStatus = useCallback(async () => {

--- a/ios/ExpoIapHelper.swift
+++ b/ios/ExpoIapHelper.swift
@@ -133,10 +133,8 @@ enum ExpoIapHelper {
     }
 
     static func cleanupListeners() {
-        // Cancel and clear subscriptions to prevent memory leaks
-        listeners.forEach { sub in
-            sub.cancel()
-        }
+        // Clear subscriptions to prevent memory leaks
+        // Subscription deinit will automatically call onRemove closure
         listeners.removeAll()
     }
 

--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -19,11 +19,11 @@ import {
   hasActiveSubscriptions,
   type ActiveSubscription,
   type ProductTypeInput,
-  restorePurchases,
 } from './index';
 import {
   getPromotedProductIOS,
   requestPurchaseOnPromotedProductIOS,
+  syncIOS,
 } from './modules/ios';
 
 // Types
@@ -82,7 +82,6 @@ type UseIap = {
 export interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
   shouldAutoSyncPurchases?: boolean; // New option to control auto-syncing
   onPromotedProductIOS?: (product: Product) => void;
 }
@@ -321,7 +320,11 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   // Android: fetch available purchases directly.
   const restorePurchasesInternal = useCallback(async (): Promise<void> => {
     try {
-      await restorePurchases();
+      // iOS: Try to sync first, but don't fail if sync errors occur
+      if (Platform.OS === 'ios') {
+        await syncIOS(); // syncIOS returns Promise<boolean>, we don't need the result
+      }
+
       const purchases = await getAvailablePurchases({
         alsoPublishToEventListenerIOS: false,
         onlyIncludeActiveItemsIOS: true,


### PR DESCRIPTION
Remove onSyncError callback from useIAP hook and fix iOS subscription cleanup to use proper Subscription type.