### PR TITLE
feat(ios): add runtime install check for expo-onside marketplace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "expo-iap",
+      "dependencies": {
+        "expo-onside": "^1.0.2",
+      },
       "devDependencies": {
         "@jest/globals": "^30.0.5",
         "@types/jest": "^30.0.0",
@@ -703,6 +706,8 @@
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.5", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg=="],
 
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
+
     "babel-plugin-react-native-web": ["babel-plugin-react-native-web@0.19.13", "", {}, "sha512-4hHoto6xaN23LCyZgL9LJZc3olmAxd7b6jDzlZnKXAh4rRAbZRKNBJoOOdp46OBqgy+K0t0guTj5/mhA8inymQ=="],
 
     "babel-plugin-syntax-hermes-parser": ["babel-plugin-syntax-hermes-parser@0.29.1", "", { "dependencies": { "hermes-parser": "0.29.1" } }, "sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA=="],
@@ -1006,6 +1011,8 @@
     "expo-modules-autolinking": ["expo-modules-autolinking@2.1.14", "", { "dependencies": { "@expo/spawn-async": "^1.7.2", "chalk": "^4.1.0", "commander": "^7.2.0", "find-up": "^5.0.0", "glob": "^10.4.2", "require-from-string": "^2.0.2", "resolve-from": "^5.0.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-nT5ERXwc+0ZT/pozDoJjYZyUQu5RnXMk9jDGm5lg+PiKvsrCTSA/2/eftJGMxLkTjVI2MXp5WjSz3JRjbA7UXA=="],
 
     "expo-modules-core": ["expo-modules-core@2.5.0", "", { "dependencies": { "invariant": "^2.2.4" } }, "sha512-aIbQxZE2vdCKsolQUl6Q9Farlf8tjh/ROR4hfN1qT7QBGPl1XrJGnaOKkcgYaGrlzCPg/7IBe0Np67GzKMZKKQ=="],
+
+    "expo-onside": ["expo-onside@1.0.2", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-sCJD+DWR1OAnxvzLFp8yoUP4E8qLfH2Ai3WYTbGxJlXRo0Dw3fLg0pSqq1NOji+qMAGkfZ2QwgynrL3AaQNs6A=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.2", "", {}, "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA=="],
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
   moduleNameMapper: {
     '^react-native$': '<rootDir>/src/__mocks__/react-native.js',
     '^expo-modules-core$': '<rootDir>/src/__mocks__/expo-modules-core.js',
+    '^expo-onside$': '<rootDir>/src/__mocks__/expo-onside.js',
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
   },
   "expo": {
     "plugin": "./app.plugin.js"
+  },
+  "dependencies": {
+    "expo-onside": "^1.0.2"
   }
 }

--- a/src/ExpoIapModule.ts
+++ b/src/ExpoIapModule.ts
@@ -1,4 +1,5 @@
 import {requireNativeModule, UnavailabilityError} from 'expo-modules-core';
+import {installedFromOnside} from 'expo-onside';
 
 type NativeIapModuleName = 'ExpoIapOnside' | 'ExpoIap';
 
@@ -23,7 +24,7 @@ function resolveNativeModule(): {
       const module = requireNativeModule(name);
       if (
         name === 'ExpoIapOnside' &&
-        module?.IS_ONSIDE_KIT_INSTALLED_IOS === false
+        (module?.IS_ONSIDE_KIT_INSTALLED_IOS === false || !installedFromOnside)
       ) {
         continue;
       }

--- a/src/__mocks__/expo-onside.js
+++ b/src/__mocks__/expo-onside.js
@@ -1,0 +1,3 @@
+module.exports = {
+  installedFromOnside: false,
+};

--- a/src/modules/__tests__/ios.test.ts
+++ b/src/modules/__tests__/ios.test.ts
@@ -1,6 +1,8 @@
 // Mock the native module first
 jest.mock('../../ExpoIapModule');
 
+jest.mock('expo-onside');
+
 // Mock React Native's Linking module
 jest.mock('react-native', () => ({
   Linking: {


### PR DESCRIPTION
Added a pre-IAP initialization check to ensure the app was installed via the Onside Store (the app is synced from Apple Store Connect to Onside after notarization). Based on this check, the SDK now selects and initializes the appropriate payment module at runtime (Onside Payments or Apple StoreKit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Onside platform with automatic availability detection to enable platform-specific functionality when present.

* **Chores**
  * Added new runtime dependency and updated test infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->