### PR TITLE
fix(types): preserve discriminated union for fetchProducts type all

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -13,9 +13,9 @@ public final class ExpoIapModule: Module {
     nonisolated public func definition() -> ModuleDefinition {
         Name("ExpoIap")
 
-        Constants(
+        Constants([
             "ERROR_CODES": OpenIapSerialization.errorCodes()
-        )
+        ])
 
         Events(
             OpenIapEvent.purchaseUpdated.rawValue,

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -9,24 +9,11 @@ import {
 } from '../utils/errorMapping';
 import {ErrorCode} from '../types';
 
-jest.mock('../ExpoIapModule', () => ({
-  __esModule: true,
-  default: {
-    // Both iOS and Android export 'ERROR_CODES'
-    ERROR_CODES: {
-      // ErrorCode.AlreadyOwned
-      'already-owned': 'ALREADY_OWNED',
-      // ErrorCode.BillingUnavailable
-      'billing-unavailable': 3,
-      // ErrorCode.NetworkError
-      'network-error': 'NATIVE_NETWORK',
-      // ErrorCode.Unknown
-      unknown: 'NATIVE_UNKNOWN',
-      // ErrorCode.UserCancelled
-      'user-cancelled': 'USER_CANCELLED',
-    },
-  },
-  NATIVE_ERROR_CODES: {
+jest.mock('../ExpoIapModule', () => {
+  // Both iOS and Android export 'ERROR_CODES'
+  // Define once and reuse to match actual implementation where
+  // NATIVE_ERROR_CODES = ExpoIapModule.ERROR_CODES || {}
+  const mockErrorCodes = {
     // ErrorCode.AlreadyOwned
     'already-owned': 'ALREADY_OWNED',
     // ErrorCode.BillingUnavailable
@@ -37,8 +24,16 @@ jest.mock('../ExpoIapModule', () => ({
     unknown: 'NATIVE_UNKNOWN',
     // ErrorCode.UserCancelled
     'user-cancelled': 'USER_CANCELLED',
-  },
-}));
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      ERROR_CODES: mockErrorCodes,
+    },
+    NATIVE_ERROR_CODES: mockErrorCodes,
+  };
+});
 
 describe('errorMapping utilities', () => {
   it('creates purchase error from platform code string', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the "user-cancelled" error is consistently exposed in exported error codes across platforms (now available via the ERROR_CODES export), improving recognition of user-cancelled operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->