### PR TITLE
fix: ensure consistent error codes between try-catch and onPurchaseError

### DIFF
--- a/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -307,12 +307,19 @@ class ExpoIapModule : Module() {
                         ExpoIapHelper.resolvePurchasePromises(purchases.map { it.toJson() })
                     } catch (e: Exception) {
                         ExpoIapLog.failure("requestPurchaseAndroid", e)
+                        // Try to use toJSON() if available (OpenIAP PurchaseError), otherwise create a generic error map
                         val errorMap =
-                            mapOf(
-                                "code" to OpenIapError.PurchaseFailed.CODE,
-                                "message" to (e.message ?: "Purchase failed"),
-                                "platform" to "android",
-                            )
+                            runCatching {
+                                @Suppress("UNCHECKED_CAST")
+                                e.javaClass.getMethod("toJSON").invoke(e) as Map<String, Any?>
+                            }.getOrElse {
+                                mapOf(
+                                    "code" to OpenIapError.PurchaseFailed.CODE,
+                                    "message" to (e.message ?: "Purchase failed"),
+                                    "platform" to "android",
+                                )
+                            }
+                        val errorCode = errorMap["code"] as? String ?: OpenIapError.PurchaseFailed.CODE
                         runCatching {
                             ExpoIapHelper.emitOrQueue(
                                 this@ExpoIapModule,
@@ -330,7 +337,7 @@ class ExpoIapModule : Module() {
                             )
                         }
                         ExpoIapHelper.rejectPurchasePromises(
-                            OpenIapError.PurchaseFailed.CODE,
+                            errorCode,
                             e.message,
                             null,
                         )

--- a/ios/ExpoIapHelper.swift
+++ b/ios/ExpoIapHelper.swift
@@ -1,5 +1,23 @@
+import ExpoModulesCore
 import Foundation
 import OpenIAP
+
+/// Exception wrapper for PurchaseError that preserves OpenIAP error codes
+/// This ensures consistent error format between try-catch and onPurchaseError callback
+class IapException: GenericException<(code: String, message: String, productId: String?)> {
+    override var code: String { param.code }
+    override var reason: String { param.message }
+
+    var productId: String? { param.productId }
+
+    static func from(_ error: PurchaseError) -> IapException {
+        let payload = OpenIapSerialization.encode(error)
+        let code = payload["code"] as? String ?? "unknown"
+        let message = payload["message"] as? String ?? error.localizedDescription
+        let productId = payload["productId"] as? String
+        return IapException((code: code, message: message, productId: productId))
+    }
+}
 
 enum ExpoIapHelper {
     private static var listeners: [Subscription] = []

--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -86,10 +86,11 @@ public final class ExpoIapModule: Module {
                 }
             } catch let error as PurchaseError {
                 ExpoIapLog.failure("requestPurchase", error: error)
-                throw error
+                throw IapException.from(error)
             } catch {
                 ExpoIapLog.failure("requestPurchase", error: error)
-                throw PurchaseError.make(code: .purchaseError, message: error.localizedDescription)
+                throw IapException.from(
+                    PurchaseError.make(code: .purchaseError, message: error.localizedDescription))
             }
         }
 
@@ -198,10 +199,10 @@ public final class ExpoIapModule: Module {
                 return sanitized
             } catch let error as PurchaseError {
                 ExpoIapLog.failure("validateReceiptIOS", error: error)
-                throw error
+                throw IapException.from(error)
             } catch {
                 ExpoIapLog.failure("validateReceiptIOS", error: error)
-                throw PurchaseError.make(code: .receiptFailed)
+                throw IapException.from(PurchaseError.make(code: .receiptFailed))
             }
         }
 
@@ -312,10 +313,10 @@ public final class ExpoIapModule: Module {
                 return nil
             } catch let error as PurchaseError {
                 ExpoIapLog.failure("currentEntitlementIOS", error: error)
-                throw error
+                throw IapException.from(error)
             } catch {
                 ExpoIapLog.failure("currentEntitlementIOS", error: error)
-                throw PurchaseError.make(code: .skuNotFound, productId: sku)
+                throw IapException.from(PurchaseError.make(code: .skuNotFound, productId: sku))
             }
         }
 
@@ -332,10 +333,10 @@ public final class ExpoIapModule: Module {
                 return nil
             } catch let error as PurchaseError {
                 ExpoIapLog.failure("latestTransactionIOS", error: error)
-                throw error
+                throw IapException.from(error)
             } catch {
                 ExpoIapLog.failure("latestTransactionIOS", error: error)
-                throw PurchaseError.make(code: .skuNotFound, productId: sku)
+                throw IapException.from(PurchaseError.make(code: .skuNotFound, productId: sku))
             }
         }
 


### PR DESCRIPTION
Resolve https://github.com/hyochan/expo-iap/issues/261#issuecomment-3576385609 in #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for in-app purchase operations. Both Android and iOS platforms now deliver more consistent error codes and structured error messages during purchase failures, enhancing error reporting and providing clearer feedback when transactions fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->