### PR TITLE
Fix ambiguous 'Subscription' type reference in ExpoIapHelper.swift

### DIFF
--- a/ios/ExpoIapHelper.swift
+++ b/ios/ExpoIapHelper.swift
@@ -21,8 +21,7 @@ final class IapException: GenericException<(code: String, message: String, produ
 
 enum ExpoIapHelper {
     // Disambiguate Subscription type to the one provided by OpenIAP
-    private typealias IAPSubscription = OpenIAP.Subscription
-    private static var listeners: [IAPSubscription] = []
+    private static var listeners: [OpenIAP.Subscription] = []
 
     static func sanitizeDictionary(_ dictionary: [String: Any?]) -> [String: Any] {
         var result: [String: Any] = [:]


### PR DESCRIPTION
## Description
This PR resolves a type ambiguity issue in `ExpoIapHelper.swift`.

The generic class name `Subscription` creates conflicts with other libraries that define a type with the same name (e.g., Combine or other Expo modules).

## Changes
- Introduced a private typealias `IAPSubscription` pointing explicitly to `OpenIAP.Subscription`.
- Updated the `listeners` array to use the unambiguous type.

## Implementation details
Old:
```swift
private static var listeners: [Subscription] = []
```
New:
```swift
private typealias IAPSubscription = OpenIAP.Subscription
private static var listeners: [IAPSubscription] = []
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Disambiguated the subscription type used for in-app purchase handling and clarified listener storage to improve code clarity and alignment with the payment framework.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->