### PR TITLE
fix(ios): Add OnsideKit as a default dependency in ExpoIap.podspec

### DIFF
--- a/ios/ExpoIap.podspec
+++ b/ios/ExpoIap.podspec
@@ -26,9 +26,13 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.dependency 'openiap', "#{versions['apple']}"
 
-  # OnsideKit is optional; added via ensureOnsidePodIOS() in Podfile when modules.onside is enabled
-  # A post_install hook makes OnsideKit visible to ExpoIap so #if canImport(OnsideKit) works.
-  # Once OnsideKit is published to CocoaPods CDN, this can be replaced with a subspec dependency.
+  # OnsideKit is optional; only included when modules.onside is enabled via the Expo plugin.
+  # The plugin adds `pod 'ExpoIap/Onside'` to the Podfile when onside is enabled.
+  s.subspec 'Onside' do |ss|
+    ss.dependency 'OnsideKit'
+  end
+
+  s.default_subspecs = []
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/plugin/__tests__/withIAP.test.ts
+++ b/plugin/__tests__/withIAP.test.ts
@@ -195,69 +195,28 @@ describe('ensureOnsidePodIOS', () => {
     '',
   ].join('\n');
 
-  it('adds OnsideKit pod and post_install hook', () => {
+  it('adds ExpoIap/Onside subspec pod', () => {
     const result = ensureOnsidePodIOS(basePodfile);
-    expect(result).toContain("pod 'OnsideKit'");
-    expect(result).toContain('# [expo-iap] Make OnsideKit visible');
-    expect(result).toContain('post_install do |installer|');
-    expect(result).toContain("target.name == 'ExpoIap'");
-    expect(result).toContain('SWIFT_INCLUDE_PATHS');
+    expect(result).toContain("pod 'ExpoIap/Onside'");
   });
 
-  it('inserts OnsideKit pod inside the target block', () => {
+  it('inserts pod inside the target block', () => {
     const result = ensureOnsidePodIOS(basePodfile);
     const targetIndex = result.indexOf("target 'MyApp' do");
-    const onsideKitIndex = result.indexOf("pod 'OnsideKit'");
+    const subspecIndex = result.indexOf("pod 'ExpoIap/Onside'");
     const endIndex = result.indexOf('end');
-    expect(onsideKitIndex).toBeGreaterThan(targetIndex);
-    expect(onsideKitIndex).toBeLessThan(endIndex);
+    expect(subspecIndex).toBeGreaterThan(targetIndex);
+    expect(subspecIndex).toBeLessThan(endIndex);
   });
 
-  it('appends into existing post_install block', () => {
-    const podfileWithPostInstall = [
+  it('skips if ExpoIap/Onside already exists', () => {
+    const podfileWithSubspec = [
       "target 'MyApp' do",
-      "  pod 'ExpoModulesCore'",
-      'end',
-      '',
-      'post_install do |installer|',
-      '  # existing hook',
+      "  pod 'ExpoIap/Onside', :path => '../node_modules/expo-iap/ios'",
       'end',
     ].join('\n');
-    const result = ensureOnsidePodIOS(podfileWithPostInstall);
-    expect(result).toContain("pod 'OnsideKit'");
-    expect(result).toContain('# [expo-iap] Make OnsideKit visible');
-    // Should not create a second post_install block
-    const postInstallCount = (
-      result.match(/post_install do \|installer\|/g) ?? []
-    ).length;
-    expect(postInstallCount).toBe(1);
-  });
-
-  it('skips if OnsideKit and post_install hook already exist', () => {
-    const podfileComplete = [
-      "target 'MyApp' do",
-      "  pod 'OnsideKit', :podspec => 'https://example.com'",
-      'end',
-      '',
-      'post_install do |installer|',
-      '  # [expo-iap] Make OnsideKit visible',
-      'end',
-    ].join('\n');
-    const result = ensureOnsidePodIOS(podfileComplete);
-    expect(result).toBe(podfileComplete);
-  });
-
-  it('adds post_install hook when OnsideKit already exists', () => {
-    const podfileWithOnsideKit = [
-      "target 'MyApp' do",
-      "  pod 'OnsideKit', :podspec => 'https://example.com'",
-      'end',
-    ].join('\n');
-    const result = ensureOnsidePodIOS(podfileWithOnsideKit);
-    expect(result).toContain('# [expo-iap] Make OnsideKit visible');
-    // Should not add a duplicate OnsideKit pod
-    const onsideKitCount = (result.match(/pod 'OnsideKit'/g) ?? []).length;
-    expect(onsideKitCount).toBe(1);
+    const result = ensureOnsidePodIOS(podfileWithSubspec);
+    expect(result).toBe(podfileWithSubspec);
   });
 
   it('returns unchanged content when no target block found', () => {
@@ -275,8 +234,7 @@ describe('ensureOnsidePodIOS', () => {
     }
 
     expect(content).toBe(basePodfile);
-    expect(content).not.toContain("pod 'OnsideKit'");
-    expect(content).not.toContain('# [expo-iap] Make OnsideKit visible');
+    expect(content).not.toContain("pod 'ExpoIap/Onside'");
   });
 
   it('modifies Podfile when onside is enabled', () => {
@@ -288,7 +246,6 @@ describe('ensureOnsidePodIOS', () => {
     }
 
     expect(content).not.toBe(basePodfile);
-    expect(content).toContain("pod 'OnsideKit'");
-    expect(content).toContain('# [expo-iap] Make OnsideKit visible');
+    expect(content).toContain("pod 'ExpoIap/Onside'");
   });
 });

--- a/plugin/src/withIAP.ts
+++ b/plugin/src/withIAP.ts
@@ -262,75 +262,28 @@ const withIapAndroid: ConfigPlugin<
   return config;
 };
 
-const ONSIDEKIT_PODSPEC_URL =
-  'https://raw.githubusercontent.com/onside-io/OnsideKit-iOS/0.5.0/OnsideKit.podspec';
-
-// post_install hook that adds OnsideKit's module to ExpoIap's search paths
-// so that `#if canImport(OnsideKit)` resolves correctly at build time.
-// This is needed because OnsideKit is not yet on CocoaPods CDN, so we cannot
-// use a podspec `s.dependency`. Once OnsideKit is on CDN, replace with a subspec.
-const ONSIDE_POST_INSTALL_HOOK = `
-  # [expo-iap] Make OnsideKit visible to ExpoIap for #if canImport(OnsideKit)
-  installer.pods_project.targets.each do |target|
-    if target.name == 'ExpoIap'
-      target.build_configurations.each do |config|
-        swift_paths = config.build_settings['SWIFT_INCLUDE_PATHS'] || '$(inherited)'
-        onside_path = '\${PODS_CONFIGURATION_BUILD_DIR}/OnsideKit'
-        unless swift_paths.include?(onside_path)
-          config.build_settings['SWIFT_INCLUDE_PATHS'] = "#{swift_paths} #{onside_path}"
-        end
-      end
-    end
-  end`;
-
-const ONSIDE_POST_INSTALL_MARKER = '# [expo-iap] Make OnsideKit visible';
+const EXPO_IAP_IOS_PATH = '../node_modules/expo-iap/ios';
 
 export const ensureOnsidePodIOS = (content: string): string => {
-  const alreadyHasOnsideKit = /^\s*pod\s+['"]OnsideKit['"].*$/m.test(content);
-  const alreadyHasPostInstall = content.includes(ONSIDE_POST_INSTALL_MARKER);
-
-  if (alreadyHasOnsideKit && alreadyHasPostInstall) {
+  if (/^\s*pod\s+['"]ExpoIap\/Onside['"].*$/m.test(content)) {
     return content;
   }
 
-  let result = content;
-
-  // 1) Add OnsideKit pod inside the target block
-  if (!alreadyHasOnsideKit) {
-    const targetMatch = result.match(/target\s+'[^']+'\s+do\s*\n/);
-    if (!targetMatch) {
-      WarningAggregator.addWarningIOS(
-        'expo-iap',
-        'Could not find a target block in Podfile when adding OnsideKit; skipping installation.',
-      );
-      return content;
-    }
-
-    const podLine = `  pod 'OnsideKit', :podspec => '${ONSIDEKIT_PODSPEC_URL}'\n`;
-    const insertIndex = targetMatch.index! + targetMatch[0].length;
-    result = result.slice(0, insertIndex) + podLine + result.slice(insertIndex);
+  const targetMatch = content.match(/target\s+'[^']+'\s+do\s*\n/);
+  if (!targetMatch) {
+    WarningAggregator.addWarningIOS(
+      'expo-iap',
+      'Could not find a target block in Podfile when adding ExpoIap/Onside; skipping installation.',
+    );
+    return content;
   }
 
-  // 2) Add post_install hook to make OnsideKit visible to ExpoIap
-  if (!alreadyHasPostInstall) {
-    const postInstallMatch = result.match(/post_install\s+do\s+\|installer\|/);
-    if (postInstallMatch) {
-      // Append inside existing post_install block
-      const insertIndex = postInstallMatch.index! + postInstallMatch[0].length;
-      result =
-        result.slice(0, insertIndex) +
-        '\n' +
-        ONSIDE_POST_INSTALL_HOOK +
-        result.slice(insertIndex);
-    } else {
-      // Create new post_install block
-      result += `\npost_install do |installer|${ONSIDE_POST_INSTALL_HOOK}\nend\n`;
-    }
-  }
+  const podLine = `  pod 'ExpoIap/Onside', :path => '${EXPO_IAP_IOS_PATH}'\n`;
+  const insertIndex = targetMatch.index! + targetMatch[0].length;
 
-  logOnce('📦 expo-iap: Added OnsideKit pod and post_install hook to Podfile');
+  logOnce('📦 expo-iap: Added ExpoIap/Onside subspec to Podfile');
 
-  return result;
+  return content.slice(0, insertIndex) + podLine + content.slice(insertIndex);
 };
 
 export type AutolinkState = {expoIap: boolean; onside: boolean};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onside is available as an optional subspec and can be enabled via the Expo plugin; OnsideKit integration supported for enabled setups.
  * Default subspecs disabled to require explicit opt-in.

* **Chores**
  * Pod insertion flow refined to avoid duplicate entries and improve installer messaging/behavior.

* **Tests**
  * Added tests validating Podfile modifications, idempotency, target handling, and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->