### PR TITLE
fix(ios): sync with Apple before reading receipt in requestReceiptRefreshIOS

### DIFF
--- a/ios/ExpoIapModule.swift
+++ b/ios/ExpoIapModule.swift
@@ -169,6 +169,7 @@ public final class ExpoIapModule: Module {
 
         AsyncFunction("requestReceiptRefreshIOS") { () async throws -> String in
             ExpoIapLog.payload("requestReceiptRefreshIOS", payload: nil)
+            _ = try await OpenIapModule.shared.syncIOS()
             let receipt = try await OpenIapModule.shared.getReceiptDataIOS() ?? ""
             ExpoIapLog.result("requestReceiptRefreshIOS", value: receipt)
             return receipt

--- a/src/__mocks__/expo-modules-core.js
+++ b/src/__mocks__/expo-modules-core.js
@@ -10,6 +10,7 @@ const mockNativeModule = {
   beginRefundRequestIOS: jest.fn(),
   showManageSubscriptionsIOS: jest.fn(),
   getReceiptDataIOS: jest.fn(),
+  requestReceiptRefreshIOS: jest.fn(),
   isTransactionVerifiedIOS: jest.fn(),
   getTransactionJwsIOS: jest.fn(),
   validateReceiptIOS: jest.fn(),

--- a/src/modules/__tests__/ios.test.ts
+++ b/src/modules/__tests__/ios.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../ExpoIapModule', () => ({
     beginRefundRequestIOS: jest.fn(),
     showManageSubscriptionsIOS: jest.fn(),
     getReceiptDataIOS: jest.fn(),
+    requestReceiptRefreshIOS: jest.fn(),
     isTransactionVerifiedIOS: jest.fn(),
     getTransactionJwsIOS: jest.fn(),
     validateReceiptIOS: jest.fn(),
@@ -49,6 +50,7 @@ import {
   beginRefundRequestIOS,
   showManageSubscriptionsIOS,
   getReceiptIOS,
+  requestReceiptRefreshIOS,
   isTransactionVerifiedIOS,
   getTransactionJwsIOS,
   validateReceiptIOS,
@@ -481,6 +483,28 @@ describe('iOS Module Functions', () => {
 
       expect(ExpoIapModule.getReceiptDataIOS).toHaveBeenCalledTimes(1);
       expect(result).toBe(mockReceipt);
+    });
+
+    it('should call requestReceiptRefreshIOS and return refreshed receipt', async () => {
+      const mockReceipt = 'refreshed-base64-receipt-data';
+
+      (ExpoIapModule.requestReceiptRefreshIOS as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      );
+
+      const result = await requestReceiptRefreshIOS();
+
+      expect(ExpoIapModule.requestReceiptRefreshIOS).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mockReceipt);
+    });
+
+    it('requestReceiptRefreshIOS should propagate errors', async () => {
+      const mockError = new Error('Sync failed');
+      (ExpoIapModule.requestReceiptRefreshIOS as jest.Mock).mockRejectedValue(
+        mockError,
+      );
+
+      await expect(requestReceiptRefreshIOS()).rejects.toThrow('Sync failed');
     });
 
     it('should call isTransactionVerifiedIOS with SKU', async () => {

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -185,6 +185,21 @@ export const getReceiptDataIOS: QueryField<'getReceiptDataIOS'> = async () => {
 export const getReceiptIOS = getReceiptDataIOS;
 
 /**
+ * Refresh the receipt data from Apple's servers and return the updated receipt.
+ * This calls AppStore.sync() before reading the receipt, ensuring the latest
+ * receipt data is available. Use this after a first purchase when
+ * getReceiptDataIOS() may return an empty string because the receipt file
+ * has not yet been written to disk.
+ *
+ * @returns {Promise<string>} Base64 encoded receipt data
+ *
+ * @platform iOS
+ */
+export const requestReceiptRefreshIOS = async (): Promise<string> => {
+  return ExpoIapModule.requestReceiptRefreshIOS();
+};
+
+/**
  * Check if a transaction is verified through StoreKit 2.
  * StoreKit 2 performs local verification of transaction JWS signatures.
  *


### PR DESCRIPTION
## Summary

- `requestReceiptRefreshIOS` was identical to `getReceiptDataIOS` — it just read the cached receipt without actually refreshing from Apple's servers
- On first purchase (especially from TestFlight with no prior sandbox account), the receipt file may not yet exist on disk, causing an empty string to be returned
- Now calls `syncIOS()` (which triggers `AppStore.sync()`) before reading the receipt, ensuring it's written to disk first
- Exposes `requestReceiptRefreshIOS` on the TypeScript side (previously only existed in Swift)

## Changes

### iOS (`ios/ExpoIapModule.swift`)
- Added `syncIOS()` call before `getReceiptDataIOS()` in `requestReceiptRefreshIOS`

### TypeScript (`src/modules/ios.ts`)
- Added `requestReceiptRefreshIOS` function export with documentation

### Tests (`src/modules/__tests__/ios.test.ts`)
- Added test for successful receipt refresh
- Added test for error propagation

### Mock (`src/__mocks__/expo-modules-core.js`)
- Added `requestReceiptRefreshIOS` mock

## Test plan

- [x] `bun run lint` passes
- [x] `bun run lint:tsc` passes
- [x] `bun run test` passes (223 tests)
- [x] `cd example && bun run test` passes (82 tests)

Closes #323

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS receipt refresh capability that automatically synchronizes before fetching updated receipt data

* **Tests**
  * Expanded test coverage to validate receipt refresh behavior and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->