### PR TITLE
fix(hooks): call refreshSubscriptionStatus for all platforms, not only iOS

### DIFF
--- a/src/useIAP.ts
+++ b/src/useIAP.ts
@@ -411,12 +411,17 @@ export function useIAP(options?: UseIAPOptions): UseIap {
         if (subscriptionsRefState.current.some((sub) => sub.id === productId)) {
           await fetchProductsInternal({skus: [productId], type: 'subs'});
           await getAvailablePurchasesInternal();
+          await getActiveSubscriptionsInternal();
         }
       } catch (error) {
         ExpoIapConsole.warn('Failed to refresh subscription status:', error);
       }
     },
-    [fetchProductsInternal, getAvailablePurchasesInternal],
+    [
+      fetchProductsInternal,
+      getAvailablePurchasesInternal,
+      getActiveSubscriptionsInternal,
+    ],
   );
 
   // Restore completed transactions with cross-platform behavior.


### PR DESCRIPTION
## Summary

Fixes a bug where Android subscription purchases did not trigger a state refresh in the `useIAP` hook's `purchaseUpdatedListener`.

## Problem

The purchase update listener was guarded by `if ('expirationDateIOS' in purchase)`:

```typescript
subscriptionsRef.current.purchaseUpdate = purchaseUpdatedListener(
  async (purchase: Purchase) => {
    if ('expirationDateIOS' in purchase) {   // ← iOS-only check
      await refreshSubscriptionStatus(purchase.id);
    }
    ...
  },
);
```

Since Android subscription purchases never have `expirationDateIOS`, the `refreshSubscriptionStatus` function was never called on Android. This meant:
- After a successful Android subscription purchase, the `activeSubscriptions` and `availablePurchases` state in the hook were **not automatically refreshed**
- Users had to manually call `getActiveSubscriptions()` or `getAvailablePurchases()` to see the updated state
- This was inconsistent with the iOS behavior and with `react-native-iap`'s hook which refreshes unconditionally

## Fix

Remove the iOS-specific guard and call `refreshSubscriptionStatus` unconditionally. The function already contains an internal guard:

```typescript
if (subscriptionsRefState.current.some((sub) => sub.id === productId)) {
  // only fetches if productId is a known subscription
}
```

So calling it for every purchase event is safe — it's a no-op for non-subscription products.

## Changes
- Removed `if ('expirationDateIOS' in purchase)` guard in the purchase update listener
- Added a comment explaining the cross-platform intent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription status is now refreshed for every purchase event, providing consistent updates across platforms and purchase types.
  * Improved matching to existing subscriptions to avoid missed or unnecessary updates, keeping subscription state accurate and timely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->