### PR TITLE
docs: clarify IAPKit relationship and reorganize purchases guide

### DIFF
--- a/docs/docs/guides/purchases.md
+++ b/docs/docs/guides/purchases.md
@@ -249,81 +249,21 @@ useEffect(() => {
 
 ## Getting Product Information
 
-### Retrieving Product Prices
-
-Here's how to get product prices across platforms:
+The cross-platform `displayPrice` field (from `ProductCommon`) provides the formatted price string for any product:
 
 ```tsx
-// Get product price by ID with proper platform checking
-const getProductPrice = (productId: string): string => {
-  if (!isReady || products.length === 0) {
-    return Platform.OS === 'ios' ? '$0.99' : '₩1,200'; // Default prices
-  }
-
-  const product = products.find((p) => p.id === productId);
-  if (!product) return Platform.OS === 'ios' ? '$0.99' : '₩1,200';
-
-  if (Platform.OS === 'ios') {
-    return product.displayPrice || '$0.99';
-  } else {
-    // Android
-    const androidProduct = product as ProductAndroid;
-    return (
-      androidProduct.oneTimePurchaseOfferDetails?.formattedPrice || '₩1,200'
-    );
-  }
-};
-
-// Get subscription price by ID with proper platform checking
-const getSubscriptionPrice = (subscriptionId: string): string => {
-  if (!isReady || subscriptions.length === 0) {
-    return Platform.OS === 'ios' ? '$9.99' : '₩11,000'; // Default prices
-  }
-
-  const subscription = subscriptions.find((s) => s.id === subscriptionId);
-  if (!subscription) return Platform.OS === 'ios' ? '$9.99' : '₩11,000';
-
-  if (Platform.OS === 'ios') {
-    return subscription.displayPrice || '$9.99';
-  } else {
-    // Android
-    const androidSubscription = subscription as ProductAndroid;
-    if (androidSubscription.subscriptionOfferDetailsAndroid?.length > 0) {
-      const firstOffer = androidSubscription.subscriptionOfferDetailsAndroid[0];
-      if (firstOffer.pricingPhases.pricingPhaseList.length > 0) {
-        return (
-          firstOffer.pricingPhases.pricingPhaseList[0].formattedPrice ||
-          '₩11,000'
-        );
-      }
-    }
-    return '₩11,000'; // Default Android price
-  }
-};
+const product = products.find((p) => p.id === productId);
+console.log(product.displayPrice); // "$4.99", "₩1,200", etc.
 ```
 
-## Platform Support
-
-### Checking Platform Compatibility
+For subscription pricing phases on Android, use `subscriptionOfferDetailsAndroid`:
 
 ```tsx
-// Define supported platforms
-const SUPPORTED_PLATFORMS = ['ios', 'android'];
+const subscription = subscriptions.find((s) => s.id === subscriptionId);
 
-export default function PurchaseScreen() {
-  const isPlatformSupported = SUPPORTED_PLATFORMS.includes(Platform.OS);
-
-  if (!isPlatformSupported) {
-    return (
-      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-        <Text>Platform Not Supported</Text>
-        <Text>In-app purchases are only available on iOS and Android.</Text>
-      </View>
-    );
-  }
-
-  // Rest of your purchase implementation
-}
+// Android: access pricing phases from offer details
+const offer = subscription?.subscriptionOfferDetailsAndroid?.[0];
+const price = offer?.pricingPhases.pricingPhaseList[0]?.formattedPrice;
 ```
 
 ## Product Types
@@ -621,19 +561,7 @@ const handlePurchaseError = (error) => {
 
 ## Testing Purchases
 
-### iOS Testing
-
-1. Create sandbox accounts in App Store Connect
-2. Sign out of App Store on device
-3. Sign in with sandbox account when prompted during purchase
-4. Test with TestFlight builds
-
-### Android Testing
-
-1. Create test accounts in Google Play Console
-2. Upload signed APK to internal testing track
-3. Add test accounts to the testing track
-4. Test with signed builds (not debug builds)
+Ensure you have completed the [Prerequisites](../getting-started/prerequisites) — including real device setup and store configuration for both platforms. For detailed testing troubleshooting, see the [Troubleshooting Guide](./troubleshooting).
 
 ## Next Steps
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,6 +10,10 @@ import IapKitBanner from "@site/src/uis/IapKitBanner"; import SponsorSection fro
 
 **Expo IAP** is a powerful in-app purchase solution for Expo and React Native applications that **conforms to the [Open IAP specification](https://openiap.dev)**. It provides a unified API for handling in-app purchases across iOS and Android platforms with comprehensive error handling and modern TypeScript support.
 
+### Built-in Purchase Verification with IAPKit
+
+Expo IAP includes **[IAPKit](https://iapkit.com)** integration out of the box — no extra dependencies required. Use `verifyPurchaseWithProvider()` to verify purchases server-side on both iOS and Android with a single API call. Just add your IAPKit API key to the config plugin and you're ready to go. See the [Purchase Verification guide](./guides/purchases#purchase-verification) for details.
+
 If you're shipping an app with expo-iap, we’d love to hear about it—please share your product and feedback in [Who’s using Expo IAP?](https://github.com/hyochan/expo-iap/discussions/143). Community stories help us keep improving the ecosystem.
 
 ## Promotion


### PR DESCRIPTION
## Summary
- Add IAPKit built-in explanation to docs intro so users understand it's included out of the box, not a separate product
- Simplify Getting Product Information section: use cross-platform `displayPrice` instead of deprecated platform-specific `formattedPrice`
- Remove verbose Platform Support section (already covered in intro page)
- Consolidate Testing section to reference Prerequisites page instead of repeating store setup steps
- Net reduction of ~70 lines of duplicated/verbose content

## Changes
- **`docs/docs/index.md`**: Added "Built-in Purchase Verification with IAPKit" section explaining the relationship
- **`docs/docs/guides/purchases.md`**: Simplified product info section, removed Platform Support boilerplate, consolidated testing section

## Test plan
- [x] Verify docs build succeeds
- [x] Verify IAPKit explanation renders correctly on intro page

Closes #317
Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)